### PR TITLE
Authenticate user on routes

### DIFF
--- a/app/controllers/aces/soap/atp_requests_controller.rb
+++ b/app/controllers/aces/soap/atp_requests_controller.rb
@@ -5,8 +5,8 @@ module Aces
     # Accepts and processes requests to OpenHBX that originate from the ACES
     # system.
     class AtpRequestsController < ApplicationController
-      skip_before_action :verify_authenticity_token, only: [:wsdl, :service]
-      skip_before_action :authenticate_user!, only: [:wsdl, :service]
+      # skip_before_action :verify_authenticity_token, only: [:wsdl, :service]
+      # skip_before_action :authenticate_user!, only: [:wsdl, :service]
 
       def wsdl
         render "wsdl.wsdl", layout: false, formats: [:wsdl], content_type: "text/xml"

--- a/app/controllers/aces/soap/atp_requests_controller.rb
+++ b/app/controllers/aces/soap/atp_requests_controller.rb
@@ -5,7 +5,7 @@ module Aces
     # Accepts and processes requests to OpenHBX that originate from the ACES
     # system.
     class AtpRequestsController < ApplicationController
-      # skip_before_action :verify_authenticity_token, only: [:wsdl, :service]
+      skip_before_action :verify_authenticity_token, only: [:wsdl, :service]
       # skip_before_action :authenticate_user!, only: [:wsdl, :service]
 
       def wsdl

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,36 @@
 Rails.application.routes.draw do
 
   devise_for :users
-  root 'reports#events'
 
+  # Must authenticate on routes for Devise to work with Stimulus Reflex/CableReady
+  authenticate :user do
+    root 'reports#events'
+
+    namespace :medicaid do
+      resources :applications, only: [:show]
+    end
+
+    resources :reports, only: [] do
+      collection do
+        get 'medicaid_applications'
+        get 'account_transfers'
+        get 'account_transfers_to_enroll'
+        get 'transfer_summary'
+        get 'medicaid_application_check'
+        get 'mec_checks'
+        get 'events'
+      end
+    end
+
+    namespace :aces do
+      resources :inbound_transfers, only: [:show]
+      resources :transfers, only: [:show]
+    end
+  end
+
+  # Requests to external services -- no user authentication
   namespace :aces do
     resource :publishing_connectivity_tests, only: [:new, :create]
-    resources :inbound_transfers, only: [:show]
-    resources :transfers, only: [:show]
     namespace :soap do
       resource :atp_requests, only: [] do
         collection do
@@ -18,21 +42,4 @@ Rails.application.routes.draw do
       end
     end
   end
-
-  namespace :medicaid do
-    resources :applications, only: [:show]
-  end
-
-  resources :reports, only: [] do
-    collection do
-      get 'medicaid_applications'
-      get 'account_transfers'
-      get 'account_transfers_to_enroll'
-      get 'transfer_summary'
-      get 'medicaid_application_check'
-      get 'mec_checks'
-      get 'events'
-    end
-  end
-
 end


### PR DESCRIPTION
ME-180721998

There is a [known issue](https://github.com/heartcombo/devise/blob/8593801130f2df94a50863b5db535c272b00efe1/test/rails_app/app/controllers/streaming_controller.rb) with Devise's StreamingController and production in Rails>=5.  The [suggested workaround](https://github.com/heartcombo/devise/issues/2332) is implemented in this PR to allow Devise authentication and Stimulus Reflex/CableReady to cooperate.