### PR TITLE
Disable hiredis gem

### DIFF
--- a/.docker/config/production.rb
+++ b/.docker/config/production.rb
@@ -6,13 +6,16 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
   # config.cache_store = :memory_store
-  config.cache_store = :redis_cache_store, { driver: :hiredis, url: "redis://#{ENV['REDIS_HOST_MEDICAID_GATEWAY']}:6379/1" }
+  config.cache_store = :redis_cache_store, {
+    # driver: :hiredis,
+    url: "redis://#{ENV['REDIS_HOST_MEDICAID_GATEWAY']}:6379/1"
+  }
 
   config.session_store :redis_session_store,
                        key: "_session_production",
                        serializer: :json,
                        redis: {
-                         driver: :hiredis,
+                         #  driver: :hiredis,
                          expire_after: 1.year,
                          ttl: 1.year,
                          key_prefix: "app:session:",

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0', :require => ["redis", "redis/connection/hiredis"]
-gem "hiredis"
+gem 'redis', '~> 4.0' #, :require => ["redis", "redis/connection/hiredis"]
+# gem "hiredis"
 gem 'redis-session-store'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0' #, :require => ["redis", "redis/connection/hiredis"]
+gem 'redis', '~> 4.0' # , :require => ["redis", "redis/connection/hiredis"]
 # gem "hiredis"
 gem 'redis-session-store'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,6 @@ GEM
       raabro (~> 1.4)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    hiredis (0.6.3)
     httparty (0.19.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -581,7 +580,6 @@ DEPENDENCIES
   eye (= 0.10.0)
   factory_bot_rails (~> 6.2)
   faraday (~> 1.4.1)
-  hiredis
   httparty (~> 0.16)
   jbuilder (~> 2.7)
   kaminari-actionview


### PR DESCRIPTION
ME-180721998

* hiredis is not compatible with Redis 6, which is used in production.