### PR TITLE
Flash alert and notice on outbound transfer test page

### DIFF
--- a/app/controllers/aces/transfers_controller.rb
+++ b/app/controllers/aces/transfers_controller.rb
@@ -21,17 +21,17 @@ module Aces
       result = ::Transfers::ToService.new.call(parsed)
 
       if result.success?
-        flash[:success] = 'Successfully sent payload'
+        flash[:notice] = 'Successfully sent payload'
         redirect_to account_transfers_reports_path
       else
         error = result.failure[:failure]
         outbound_transfer = Aces::Transfer.find(result.failure[:transfer_id])
         outbound_transfer.update!(failure: error)
-        flash[:error] = "Error: #{error}"
+        flash[:alert] = "Error: #{error}"
         redirect_to new_aces_transfer_path
       end
     rescue StandardError => e
-      flash[:error] = "Exception raised: #{e}"
+      flash[:alert] = "Exception raised: #{e}"
       redirect_to new_aces_transfer_path
     end
 

--- a/spec/controllers/aces/transfers_controllers_spec.rb
+++ b/spec/controllers/aces/transfers_controllers_spec.rb
@@ -1414,17 +1414,17 @@ module Aces
       end
 
       context 'with valid payload - hash format' do
-        it 'redirects with success flash ' do
+        it 'redirects with notice flash ' do
           expect(response).to have_http_status(:redirect)
-          expect(flash[:success]).to match(/Successfully sent payload/)
+          expect(flash[:notice]).to match(/Successfully sent payload/)
         end
       end
 
       context 'with valid payload - JSON format' do
-        it 'redirects with success flash ' do
+        it 'redirects with notice flash ' do
           post :create, params: { transfer: { :outbound_payload => outbound_payload_json } }
           expect(response).to have_http_status(:redirect)
-          expect(flash[:success]).to match(/Successfully sent payload/)
+          expect(flash[:notice]).to match(/Successfully sent payload/)
         end
       end
 
@@ -1433,9 +1433,9 @@ module Aces
           {}
         end
 
-        it 'redirects with error flash' do
+        it 'redirects with alert flash' do
           expect(response).to have_http_status(:redirect)
-          expect(flash[:error]).to match(/Exception raised/)
+          expect(flash[:alert]).to match(/Exception raised/)
         end
       end
     end


### PR DESCRIPTION
ME-180968958

- Switching from flash :success and :error to flash :notice and :alert so that messages are displayed in the UI and failures on the outbound test page are not silent.  This pattern is consistent with other controllers and the application layout view.