### PR TITLE
expect symbolized keys in transfer subscriber phash

### DIFF
--- a/app/event_source/subscribers/transfer_subscriber.rb
+++ b/app/event_source/subscribers/transfer_subscriber.rb
@@ -18,7 +18,7 @@ module Subscribers
       phash = JSON.parse(response, symbolize_names: true)
 
       result = if transfer
-                 ::Transfers::ToService.new.call(JSON.generate(phash.except("service")))
+                 ::Transfers::ToService.new.call(JSON.generate(phash.except(:service)))
                else
                  ::Transfers::AddEnrollResponse.new.call(phash)
                end
@@ -49,7 +49,7 @@ module Subscribers
           }
         )
       else
-        ib_transfer_id = phash["transfer_id"]
+        ib_transfer_id = phash[:transfer_id]
         inbound_transfer = Aces::InboundTransfer.where(external_id: ib_transfer_id).last
         inbound_transfer&.update!(failure: true)
       end

--- a/app/operations/transfers/add_enroll_response.rb
+++ b/app/operations/transfers/add_enroll_response.rb
@@ -30,7 +30,7 @@ module Transfers
 
     def update_transfer(params, transfers)
       result = Try do
-        params[:payload] = "" if params["result"] == "Success"
+        params[:payload] = "" if params[:result] == "Success"
         transfers.each do |transfer|
           transfer.update!(params.except(:transfer_id))
         end

--- a/spec/domain/operations/transfers/add_enroll_response_spec.rb
+++ b/spec/domain/operations/transfers/add_enroll_response_spec.rb
@@ -20,8 +20,14 @@ describe Transfers::AddEnrollResponse, dbclean: :after_each do
   let(:operation) { Transfers::AddEnrollResponse.new }
 
   context "failure" do
+    it "should fail if the param keys are not symbolized" do
+      invalid_params = params.stringify_keys
+      result = operation.call(invalid_params)
+      expect(result.failure).to eq("Param keys must be symbols. Found non-symbol keys: #{invalid_params.keys}")
+    end
+
     it "should fail if the inbound transfer record does not exist" do
-      result = operation.call(params.stringify_keys)
+      result = operation.call(params)
       expect(result.success?).not_to be_truthy
     end
   end
@@ -29,7 +35,7 @@ describe Transfers::AddEnrollResponse, dbclean: :after_each do
   context "success" do
     before :each do
       @inbound_transfer = create :inbound_transfer, external_id: transfer_id
-      @result = operation.call(params.stringify_keys)
+      @result = operation.call(params)
     end
 
     it "should update the inbound transfer with the response details from enroll" do


### PR DESCRIPTION
ME-181253041
- use symbols instead of strings to access TransferSubscriber params hash
- add validation method in AddEnrollResponse to confirm keys are symbols
- spec coverage for new validation method