### PR TITLE
skip pundit authorization on reflex actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,12 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  # override Pundit authorize method to skip authorization on reflexes
+  def authorize(record, query = nil)
+    return if @stimulus_reflex
+    super(record, query)
+  end
+
   def user_not_authorized(_exception)
     respond_to do |format|
       format.json { render nothing: true, status: :forbidden }


### PR DESCRIPTION
ME-181793007

- Pundit's authorize method was blocking stimulus reflex actions from completing.  The authorize method has been overridden to skip authorization when the server is responding to a reflex action.
- A similar issue (and solution) occurred when stimulus reflex was first set up with devise authentication.