### PR TITLE
display fpl % per household on determinations

### DIFF
--- a/app/views/medicaid/applications/show.html.erb
+++ b/app/views/medicaid/applications/show.html.erb
@@ -44,7 +44,7 @@
               <td><% benchmark = @application.benchmarks.detect{ |a| a[:member_identifier] == thm[:applicant_reference][:person_hbx_id]} %>
                 <%= benchmark[:monthly_premium] if benchmark %>
               </td>
-              <td><%= @application.aptc_households&.last&.fpl_percent %>%</td>
+              <td><%= @application.aptc_households&.detect { |hh| thm[:applicant_reference][:person_hbx_id].in? (hh&.aptc_household_members&.map(&:member_identifier)) }&.fpl_percent  %>%</td>
               <td><%= thm[:product_eligibility_determination][:is_magi_medicaid] %></td>
               <td><%= thh[:max_aptc] unless mm_eligible %></td>
               <td><%=  @application.aptc_households&.last&.contribution_percent unless mm_eligible %></td>


### PR DESCRIPTION
[IVL-181590019](https://www.pivotaltracker.com/n/projects/2481183/stories/181590019)

This PR addresses the defect logged in [redmine ticket 98285](https://redmine.dchbx.org/issues/98285) with the same FPL appearing for both households