### PR TITLE
skip updating rubygems to latest version

### DIFF
--- a/.docker/production/Dockerfile.gha
+++ b/.docker/production/Dockerfile.gha
@@ -70,7 +70,7 @@ ENV HOME=/medicaid_gateway
 
 ENV PATH=$HOME/bin:$BUNDLE_BIN:$GEM_HOME/gems/bin:$PATH
 
-RUN gem update --system
+# RUN gem update --system
 RUN rm -f /usr/local/bin/ruby/gems/*/specifications/default/bundler-*.gemspec
 RUN gem install bundler -v $BUNDLER_VERSION
 


### PR DESCRIPTION
Updating RubyGems to the latest version when building the Docker image was resulting in failure to build due to conflicts with existing dependencies.  Removing this step restores build success.