### PR TITLE
drop awesome print indexes from payloads in UI

### DIFF
--- a/app/views/aces/transfers/show.html.erb
+++ b/app/views/aces/transfers/show.html.erb
@@ -16,17 +16,17 @@
 
 <% unless @response_payload.blank? %>
 <h2>Response Payload:</h2>
-<%= raw(ap(@response_payload)) %>
+<%= raw(ap(@response_payload, index: false)) %>
 <% end %>
 
 <% unless @callback_payload.blank? %>
 <h2>Callback Payload:</h2>
-<%= raw(ap(@callback_payload)) %>
+<%= raw(ap(@callback_payload, index: false)) %>
 <% end %>
 
 <% unless @outbound_payload.blank? %>
 <h2>Payload from Enroll:</h2>
-<%= raw(ap(@outbound_payload)) %>
+<%= raw(ap(@outbound_payload, index: false)) %>
 <% end %>
 
 <% unless @transfer.xml_payload.blank? %>

--- a/app/views/medicaid/applications/show.html.erb
+++ b/app/views/medicaid/applications/show.html.erb
@@ -83,28 +83,28 @@
     <input type="checkbox" id="chck1" checked>
     <label class="accordion_panel-label" for="chck1"><h3>Application Request Payload (from Enroll)</h3></label>
     <div class="accordion_panel-content">
-      <%= raw(ap(@application_request_payload)) %>
+      <%= raw(ap(@application_request_payload, index: false)) %>
     </div>
   </div>
   <div class="accordion_panel">
     <input type="checkbox" id="chck2" checked>
     <label class="accordion_panel-label" for="chck2"><h3>Medicaid Request Payload (to MitC)</h3></label>
     <div class="accordion_panel-content">
-      <%= raw(ap(@medicaid_request_payload)) %>
+      <%= raw(ap(@medicaid_request_payload, index: false)) %>
     </div>
   </div>
   <div class="accordion_panel">
     <input type="checkbox" id="chck3" checked>
     <label class="accordion_panel-label" for="chck3"><h3>Medicaid Response Payload (from MitC)</h3></label>
     <div class="accordion_panel-content">
-      <%= raw(ap(@medicaid_response_payload)) %>
+      <%= raw(ap(@medicaid_response_payload, index: false)) %>
     </div>
   </div>
   <div class="accordion_panel">
     <input type="checkbox" id="chck4" checked>
     <label class="accordion_panel-label" for="chck4"><h3>Application Response Payload (to Enroll)</h3></label>
     <div class="accordion_panel-content">
-      <%= raw(ap(@application_response_payload)) %>
+      <%= raw(ap(@application_response_payload, index: false)) %>
     </div>
   </div>
 </div>
@@ -113,13 +113,13 @@
 <% if @application.aptc_households && @application.aptc_households.any? %>
 
 <% @application.aptc_households.each do |household| %>
-  <%= raw(ap(household.attributes)) %>
+  <%= raw(ap(household.attributes, index: false)) %>
 <% end %>
 
 <% end %>
 <hr>
 <% if @application.other_factors %>
 <h2>Other Factors</h2>
-  <%= raw(ap(@application.other_factors)) if @application.other_factors  %>
+  <%= raw(ap(@application.other_factors, index: false)) if @application.other_factors  %>
 <% end %>
 <%= link_to "Determinations Report", medicaid_application_check_reports_path, class: 'btn btn-primary' %>


### PR DESCRIPTION
- Stops awesome print from adding array indexes to displayed payloads.