### PR TITLE
bring MG reports in line with EA report

### DIFF
--- a/app/views/medicaid/applications/show.html.erb
+++ b/app/views/medicaid/applications/show.html.erb
@@ -35,7 +35,7 @@
     <% @application.application_response_payload_json[:tax_households].each do |thh| %>
       <% thh[:tax_household_members].each do |thm| %>
         <% if thm[:product_eligibility_determination] %>
-          <% mm_eligible = thm[:product_eligibility_determination][:is_magi_medicaid] %>
+          <% magi_medicaid_or_chip = thm[:product_eligibility_determination][:is_magi_medicaid] || thm[:product_eligibility_determination][:is_medicaid_chip_eligible]%>
           <tr>
             <td><%= thm[:applicant_reference][:person_hbx_id] %></td>
             <td><%= @application.relationship_for(thm[:applicant_reference][:person_hbx_id]) %></td>
@@ -45,9 +45,9 @@
                 <%= benchmark[:monthly_premium] if benchmark %>
               </td>
               <td><%= @application.aptc_households&.detect { |hh| thm[:applicant_reference][:person_hbx_id].in? (hh&.aptc_household_members&.map(&:member_identifier)) }&.fpl_percent  %>%</td>
-              <td><%= thm[:product_eligibility_determination][:is_magi_medicaid] %></td>
-              <td><%= thh[:max_aptc] unless mm_eligible %></td>
-              <td><%=  @application.aptc_households&.last&.contribution_percent unless mm_eligible %></td>
+              <td><%= magi_medicaid_or_chip %></td>
+              <td><%= thh[:max_aptc] unless magi_medicaid_or_chip %></td>
+              <td><%=  @application.aptc_households&.last&.contribution_percent unless magi_medicaid_or_chip %></td>
               <td><%= thm[:product_eligibility_determination][:csr] if thm[:product_eligibility_determination][:is_csr_eligible] %></td>
               <td><%= @application.citizen_status_for(thm[:applicant_reference][:person_hbx_id]) %></td>
               <td><%= @application.tax_filer_kind_for(thm[:applicant_reference][:person_hbx_id]) %></td>

--- a/app/views/reports/_daily_iap_determination_row.erb
+++ b/app/views/reports/_daily_iap_determination_row.erb
@@ -7,7 +7,7 @@
     <td><%= ia_eligible %></td>
     <td><%= tax_household.max_aptc if ia_eligible %></td>
     <td><%= applicant.product_eligibility_determination.csr %></td>
-    <td><%= applicant.product_eligibility_determination.is_magi_medicaid %></td>
+    <td><%= applicant.product_eligibility_determination.is_magi_medicaid || applicant.product_eligibility_determination.is_medicaid_chip_eligible %></td>
     <td><%= applicant.product_eligibility_determination.is_non_magi_medicaid_eligible %></td>
     <td><%= applicant.product_eligibility_determination.is_totally_ineligible %></td>
     <td><%= determination.application_response_entity&.submitted_at %></td>


### PR DESCRIPTION
Changes to how EA stores eligibility determination results for magi medicaid and chip (implemented as a part of DC Eligibility Engine work) have been reverted.  This PR updates the MG UI to match the determination reports generated by Enroll.