### PR TITLE
outbound transfers failures set correctly

### DIFF
--- a/app/operations/transfers/to_service.rb
+++ b/app/operations/transfers/to_service.rb
@@ -108,9 +108,10 @@ module Transfers
 
     def update_transfer(response)
       response_json = response.to_json
-      response_failure = response["status"] == 200 ? nil : "Response has a failure with status #{response['status']}"
+      response_hash = response.to_hash
+      response_failure = response_hash[:status] == 200 ? nil : "Response has a failure with status #{response_hash[:status]}"
       if @service == "aces"
-        xml = Nokogiri::XML(response.to_hash[:body])
+        xml = Nokogiri::XML(response_hash[:body])
         status = xml.xpath('//tns:ResponseDescriptionText', 'tns' => 'http://hix.cms.gov/0.1/hix-core')
         status_text = status.any? ? status.last.text : "N/A"
         payload = status_text == "Success" ? "" : @transfer.outbound_payload

--- a/app/operations/transfers/to_service.rb
+++ b/app/operations/transfers/to_service.rb
@@ -108,7 +108,7 @@ module Transfers
 
     def update_transfer(response)
       response_json = response.to_json
-      response_failure = response[:status] == 200 ? nil : "Response has a failure with status #{response[:status]}"
+      response_failure = response["status"] == 200 ? nil : "Response has a failure with status #{response['status']}"
       if @service == "aces"
         xml = Nokogiri::XML(response.to_hash[:body])
         status = xml.xpath('//tns:ResponseDescriptionText', 'tns' => 'http://hix.cms.gov/0.1/hix-core')

--- a/spec/domain/operations/transfers/to_service_spec.rb
+++ b/spec/domain/operations/transfers/to_service_spec.rb
@@ -29,7 +29,7 @@ describe Transfers::ToService, "given an ATP valid payload, transfer it to the s
 
   let(:response) do
     {
-      "status" => 200,
+      :status => 200,
       :body => response_body,
       :response_headers => {}
     }
@@ -81,7 +81,7 @@ describe Transfers::ToService, "given an ATP valid payload, transfer it to the s
     context 'with valid application transfer response not as 200' do
       let(:failure_response) do
         {
-          "status" => 504,
+          :status => 504,
           :body => response_body,
           :response_headers => {}
         }

--- a/spec/domain/operations/transfers/to_service_spec.rb
+++ b/spec/domain/operations/transfers/to_service_spec.rb
@@ -29,7 +29,7 @@ describe Transfers::ToService, "given an ATP valid payload, transfer it to the s
 
   let(:response) do
     {
-      :status => 200,
+      "status" => 200,
       :body => response_body,
       :response_headers => {}
     }
@@ -81,7 +81,7 @@ describe Transfers::ToService, "given an ATP valid payload, transfer it to the s
     context 'with valid application transfer response not as 200' do
       let(:failure_response) do
         {
-          :status => 504,
+          "status" => 504,
           :body => response_body,
           :response_headers => {}
         }


### PR DESCRIPTION
ME-183049600

This feature was not working correctly to set a failure if not a 200 as it was checking the to_json of a string so was never finding it. This change turns the response object into a hash, then checks for the status from there.