### PR TITLE
use same env var as EA for local mec check

### DIFF
--- a/config/client_config/dc/system/config/templates/features/features.yml
+++ b/config/client_config/dc/system/config/templates/features/features.yml
@@ -14,7 +14,7 @@ registry:
       - key: :mitc_determination
         is_enabled: true
       - key: :mec_check
-        is_enabled: <%= ENV['MG_MEC_CHECK_IS_ENABLED'] || false %>
+        is_enabled: <%= ENV['MEC_CHECK_IS_ENABLED'] || false %>
       - key: :resubmit_to_enroll
         is_enabled: false
       - key: :bulk_transfer_to_enroll

--- a/config/client_config/me/system/config/templates/features/features.yml
+++ b/config/client_config/me/system/config/templates/features/features.yml
@@ -14,7 +14,7 @@ registry:
       - key: :mitc_determination
         is_enabled: true
       - key: :mec_check
-        is_enabled: <%= ENV['MG_MEC_CHECK_IS_ENABLED'] || true %>
+        is_enabled: <%= ENV['MEC_CHECK_IS_ENABLED'] || true %>
       - key: :resubmit_to_enroll
         is_enabled: false
       - key: :bulk_transfer_to_enroll

--- a/system/config/templates/features/features.yml
+++ b/system/config/templates/features/features.yml
@@ -14,7 +14,7 @@ registry:
       - key: :mitc_determination
         is_enabled: true
       - key: :mec_check
-        is_enabled: <%= ENV['MG_MEC_CHECK_IS_ENABLED'] || true %>
+        is_enabled: <%= ENV['MEC_CHECK_IS_ENABLED'] || true %>
       - key: :resubmit_to_enroll
         is_enabled: false
       - key: :bulk_transfer_to_enroll


### PR DESCRIPTION
The [dchbx_k8s](https://github.com/ideacrew/dchbx_k8s) repo was updated to use a single variable across Enroll and Medicaid Gateway for enabling local MEC checks.  This PR brings MG in line with that change.