### PR TITLE
Store eligibility override flag and reason in MG

### DIFF
--- a/app/contracts/aptc_csr/member_contract.rb
+++ b/app/contracts/aptc_csr/member_contract.rb
@@ -38,7 +38,7 @@ module AptcCsr
 
       optional(:csr).maybe(Types::CsrKind)
 
-      optional(:member_determination).array(MemberDeterminationContract.params)
+      optional(:member_determinations).array(MemberDeterminationContract.params)
     end
 
     rule do

--- a/app/contracts/aptc_csr/member_contract.rb
+++ b/app/contracts/aptc_csr/member_contract.rb
@@ -37,6 +37,8 @@ module AptcCsr
       optional(:csr_eligible).maybe(:bool)
 
       optional(:csr).maybe(Types::CsrKind)
+
+      optional(:member_determination).array(MemberDeterminationContract.params)
     end
 
     rule do

--- a/app/contracts/aptc_csr/member_determination_contract.rb
+++ b/app/contracts/aptc_csr/member_determination_contract.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'types'
+
+module AptcCsr
+  # Schema and validation rules for {AptcCsr::MemberDeterminationContract}
+  class MemberDeterminationContract < Dry::Validation::Contract
+    # @!method call(opts)
+    # @param [Hash] opts the parameters to validate using this contract
+    # @return [Dry::Monads::Result]
+    params do
+      optional(:kind).maybe(Types::MemberDeterminationKind)
+      optional(:is_eligible).maybe(:bool)
+      optional(:determination_reasons).array(::Types::Symbol)
+    end
+  end
+end

--- a/app/entities/aptc_csr/member.rb
+++ b/app/entities/aptc_csr/member.rb
@@ -18,6 +18,8 @@ module AptcCsr
     attribute :magi_medicaid_eligible, Types::Bool.optional.meta(omittable: true)
     attribute :csr_eligible, Types::Bool.optional.meta(omittable: true)
 
+    attribute :member_determination, Types::Array.of(MemberDetermination).optional.meta(omittable: true)
+
     attribute :csr, Types::CsrKind.optional.meta(omittable: true)
   end
 end

--- a/app/entities/aptc_csr/member.rb
+++ b/app/entities/aptc_csr/member.rb
@@ -18,7 +18,7 @@ module AptcCsr
     attribute :magi_medicaid_eligible, Types::Bool.optional.meta(omittable: true)
     attribute :csr_eligible, Types::Bool.optional.meta(omittable: true)
 
-    attribute :member_determination, Types::Array.of(MemberDetermination).optional.meta(omittable: true)
+    attribute :member_determinations, Types::Array.of(MemberDetermination).optional.meta(omittable: true)
 
     attribute :csr, Types::CsrKind.optional.meta(omittable: true)
   end

--- a/app/entities/aptc_csr/member.rb
+++ b/app/entities/aptc_csr/member.rb
@@ -18,8 +18,8 @@ module AptcCsr
     attribute :magi_medicaid_eligible, Types::Bool.optional.meta(omittable: true)
     attribute :csr_eligible, Types::Bool.optional.meta(omittable: true)
 
-    attribute :member_determinations, Types::Array.of(MemberDetermination).optional.meta(omittable: true)
-
     attribute :csr, Types::CsrKind.optional.meta(omittable: true)
+
+    attribute :member_determinations, Types::Array.of(MemberDetermination).optional.meta(omittable: true)
   end
 end

--- a/app/entities/aptc_csr/member_determination.rb
+++ b/app/entities/aptc_csr/member_determination.rb
@@ -5,7 +5,7 @@ module AptcCsr
   class MemberDetermination < Dry::Struct
 
     attribute :kind, Types::MemberDeterminationKind
-    attribute :is_eligible, Types::Boolean
+    attribute :is_eligible, Types::Bool
     attribute :determination_reasons, Types::Array.of(Types::Symbol).optional.meta(omittable: true)
 
   end

--- a/app/entities/aptc_csr/member_determination.rb
+++ b/app/entities/aptc_csr/member_determination.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AptcCsr
+  # An entity to represent a MemberDetermination
+  class MemberDetermination < Dry::Struct
+
+    attribute :kind, Types::MemberDeterminationKind
+    attribute :is_eligible, Types::Boolean
+    attribute :determination_reasons, Types::Array.of(Types::Symbol).optional.meta(omittable: true)
+
+  end
+end

--- a/app/models/medicaid/aptc_household_member.rb
+++ b/app/models/medicaid/aptc_household_member.rb
@@ -37,8 +37,8 @@ module Medicaid
     field :csr_eligible, type: Boolean
     field :csr, type: String
 
-    embeds_many :member_determination, class_name: '::Medicaid::MemberDetermination'
-    accepts_nested_attributes_for :member_determination
+    embeds_many :member_determinations, class_name: '::Medicaid::MemberDetermination', cascade_callbacks: true
+    accepts_nested_attributes_for :member_determinations
 
     embedded_in :aptc_household, class_name: '::Medicaid::AptcHousehold'
   end

--- a/app/models/medicaid/aptc_household_member.rb
+++ b/app/models/medicaid/aptc_household_member.rb
@@ -37,6 +37,9 @@ module Medicaid
     field :csr_eligible, type: Boolean
     field :csr, type: String
 
+    embeds_many :member_determination, class_name: '::Medicaid::MemberDetermination'
+    accepts_nested_attributes_for :member_determination
+
     embedded_in :aptc_household, class_name: '::Medicaid::AptcHousehold'
   end
 end

--- a/app/models/medicaid/member_determination.rb
+++ b/app/models/medicaid/member_determination.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Medicaid
+  # Represents determnation details for a member
+  class MemberDetermination
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    # The kind of determination.
+    field :kind, type: String
+
+    # Whether or not the member is eligible for the kind of determination.
+    field :is_eligible, type: Boolean
+
+    # the reasons the member qualifies for the determination.
+    field :determination_reasons, type: Array
+
+    embedded_in :aptc_household_member, class_name: '::Medicaid::AptcHouseholdMember'
+
+  end
+end

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -11,12 +11,14 @@ module Types
 
   Money = Types.Constructor(BigDecimal) { |val| BigDecimal(val.to_s) }
 
-  TaxFilerKind = Types::Coercible::String.enum('tax_filer',
-                                               'single',
-                                               'joint',
-                                               'separate',
-                                               'dependent',
-                                               'non_filer')
+  TaxFilerKind = Types::Coercible::String.enum(
+    'tax_filer',
+    'single',
+    'joint',
+    'separate',
+    'dependent',
+    'non_filer'
+  )
 
   FplKind = Types::Coercible::Integer.enum(324, 221, 215)
 
@@ -130,12 +132,14 @@ module Types
     { 2024 => BigDecimal('9.12') }
   ].freeze
 
-  CsrKind = Types::Coercible::String.enum('0',
-                                          '73',
-                                          '87',
-                                          '94',
-                                          '100',
-                                          'limited')
+  CsrKind = Types::Coercible::String.enum(
+    '0',
+    '73',
+    '87',
+    '94',
+    '100',
+    'limited'
+  )
 
   ELIGIBLE_INSURANCE_KINDS = %w[
     medicaid
@@ -148,8 +152,25 @@ module Types
     peace_corps_health_benefits
   ].freeze
 
-  ENROLLED_INSURANCE_KINDS = ['medicaid', 'child_health_insurance_plan', 'medicare', 'medicare_advantage', 'tricare',
-                              'employer_sponsored_insurance', 'health_reimbursement_arrangement', 'cobra',
-                              'retiree_health_benefits', 'veterans_administration_health_benefits', 'peace_corps_health_benefits'].freeze
+  ENROLLED_INSURANCE_KINDS = [
+    'medicaid',
+    'child_health_insurance_plan',
+    'medicare',
+    'medicare_advantage',
+    'tricare',
+    'employer_sponsored_insurance',
+    'health_reimbursement_arrangement',
+    'cobra',
+    'retiree_health_benefits',
+    'veterans_administration_health_benefits',
+    'peace_corps_health_benefits'
+  ].freeze
+
+  MemberDeterminationKind = Types::Coercible::String.enum(
+    'Medicaid/CHIP Determination',
+    'Insurance Assistance Determination',
+    'Unassisted QHP Determination',
+    'Total Ineligibility Determination'
+  )
 
 end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -15,7 +15,7 @@ module Eligibilities
         Success(result)
       end
 
-      def apply_eligibility_overrides(params) # rubocop:disable Metrics/MethodLength
+      def apply_eligibility_overrides(params)
         @mm_application = params[:magi_medicaid_application]
         mm_app_hash = @mm_application.to_h
         mm_app_hash[:tax_households].each do |mm_thh|
@@ -31,15 +31,10 @@ module Eligibilities
                 ped[:is_magi_medicaid] = true
                 ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_under_twenty_one)
               end
-            elsif chip_ineligible_due_to_immigration_only?(thhm)
-              if pregnancy_override?(thhm)
-                ped[:is_magi_medicaid] = true
-                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_pregnant)
-              end
-              if under_eighteen_chip_override?(thhm)
-                ped[:is_medicaid_chip_eligible] = true
-                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_chip_eligible)
-              end
+            end
+            if chip_ineligible_due_to_immigration_only?(thhm) && under_eighteen_chip_override?(thhm)
+              ped[:is_medicaid_chip_eligible] = true
+              ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_chip_eligible)
             end
           end
         end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -20,10 +20,32 @@ module Eligibilities
         mm_app_hash = @mm_application.to_h
         mm_app_hash[:tax_households].each do |mm_thh|
           mm_thh[:tax_household_members].each do |thhm|
-            if only_medicaid_ineligible_due_to_immigration?(thhm) && (pregnancy_override?(thhm) || nineteen_to_twenty_one_override?(thhm))
-              thhm[:product_eligibility_determination][:is_magi_medicaid] = true
+            if only_medicaid_ineligible_due_to_immigration?(thhm)
+              if pregnancy_override?(thhm)
+                thhm[:product_eligibility_determination][:is_magi_medicaid] = true
+                thhm[:product_eligibility_determination][:member_determinations] =
+                  [{
+                    kind: 'Medicaid/CHIP Determination',
+                    is_eligible: true,
+                    determination_reasons: [:mitc_override_not_lawfully_present_pregnant]
+                  }]
+              elsif nineteen_to_twenty_one_override?(thhm)
+                thhm[:product_eligibility_determination][:is_magi_medicaid] = true
+                thhm[:product_eligibility_determination][:member_determinations] =
+                  [{
+                    kind: 'Medicaid/CHIP Determination',
+                    is_eligible: true,
+                    determination_reasons: [:mitc_override_not_lawfully_present_under_twenty_one]
+                  }]
+              end
             elsif only_chip_ineligible_due_to_immigration?(thhm) && under_eighteen_chip_override?(thhm)
               thhm[:product_eligibility_determination][:is_medicaid_chip_eligible] = true
+              thhm[:product_eligibility_determination][:member_determinations] =
+                [{
+                  kind: 'Medicaid/CHIP Determination',
+                  is_eligible: true,
+                  determination_reasons: [:mitc_override_not_lawfully_present_chip_eligible]
+                }]
             end
           end
         end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -24,28 +24,16 @@ module Eligibilities
               if pregnancy_override?(thhm)
                 thhm[:product_eligibility_determination][:is_magi_medicaid] = true
                 thhm[:product_eligibility_determination][:member_determinations] =
-                  [{
-                    kind: 'Medicaid/CHIP Determination',
-                    is_eligible: true,
-                    determination_reasons: [:mitc_override_not_lawfully_present_pregnant]
-                  }]
+                  construct_member_determination_object(:mitc_override_not_lawfully_present_pregnant)
               elsif nineteen_to_twenty_one_override?(thhm)
                 thhm[:product_eligibility_determination][:is_magi_medicaid] = true
                 thhm[:product_eligibility_determination][:member_determinations] =
-                  [{
-                    kind: 'Medicaid/CHIP Determination',
-                    is_eligible: true,
-                    determination_reasons: [:mitc_override_not_lawfully_present_under_twenty_one]
-                  }]
+                  construct_member_determination_object(:mitc_override_not_lawfully_present_under_twenty_one)
               end
             elsif only_chip_ineligible_due_to_immigration?(thhm) && under_eighteen_chip_override?(thhm)
               thhm[:product_eligibility_determination][:is_medicaid_chip_eligible] = true
               thhm[:product_eligibility_determination][:member_determinations] =
-                [{
-                  kind: 'Medicaid/CHIP Determination',
-                  is_eligible: true,
-                  determination_reasons: [:mitc_override_not_lawfully_present_chip_eligible]
-                }]
+                construct_member_determination_object(:mitc_override_not_lawfully_present_chip_eligible)
             end
           end
         end
@@ -82,6 +70,14 @@ module Eligibilities
       def only_chip_ineligible_due_to_immigration?(thhm)
         ineligibility_reasons = thhm[:product_eligibility_determination][:chip_ineligibility_reasons]
         ineligibility_reasons&.include?("Applicant did not meet citizenship/immigration requirements") && ineligibility_reasons.count == 1
+      end
+
+      def construct_member_determination_object(determ_reason)
+        [{
+          kind: 'Medicaid/CHIP Determination',
+          is_eligible: true,
+          determination_reasons: [determ_reason]
+        }]
       end
     end
   end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -15,25 +15,31 @@ module Eligibilities
         Success(result)
       end
 
-      def apply_eligibility_overrides(params)
+      def apply_eligibility_overrides(params) # rubocop:disable Metrics/MethodLength
         @mm_application = params[:magi_medicaid_application]
         mm_app_hash = @mm_application.to_h
         mm_app_hash[:tax_households].each do |mm_thh|
           mm_thh[:tax_household_members].each do |thhm|
-            if only_medicaid_ineligible_due_to_immigration?(thhm)
+            ped = thhm[:product_eligibility_determination]
+            ped[:member_determinations] ||= []
+            if medicaid_ineligible_due_to_immigration_only?(thhm)
               if pregnancy_override?(thhm)
-                thhm[:product_eligibility_determination][:is_magi_medicaid] = true
-                thhm[:product_eligibility_determination][:member_determinations] =
-                  construct_member_determination_object(:mitc_override_not_lawfully_present_pregnant)
-              elsif nineteen_to_twenty_one_override?(thhm)
-                thhm[:product_eligibility_determination][:is_magi_medicaid] = true
-                thhm[:product_eligibility_determination][:member_determinations] =
-                  construct_member_determination_object(:mitc_override_not_lawfully_present_under_twenty_one)
+                ped[:is_magi_medicaid] = true
+                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_pregnant)
               end
-            elsif only_chip_ineligible_due_to_immigration?(thhm) && under_eighteen_chip_override?(thhm)
-              thhm[:product_eligibility_determination][:is_medicaid_chip_eligible] = true
-              thhm[:product_eligibility_determination][:member_determinations] =
-                construct_member_determination_object(:mitc_override_not_lawfully_present_chip_eligible)
+              if nineteen_to_twenty_one_override?(thhm)
+                ped[:is_magi_medicaid] = true
+                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_under_twenty_one)
+              end
+            elsif chip_ineligible_due_to_immigration_only?(thhm)
+              if pregnancy_override?(thhm)
+                ped[:is_magi_medicaid] = true
+                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_pregnant)
+              end
+              if under_eighteen_chip_override?(thhm)
+                ped[:is_medicaid_chip_eligible] = true
+                ped[:member_determinations] << member_determ_for(thhm, :mitc_override_not_lawfully_present_chip_eligible)
+              end
             end
           end
         end
@@ -62,22 +68,28 @@ module Eligibilities
         end
       end
 
-      def only_medicaid_ineligible_due_to_immigration?(thhm)
+      def medicaid_ineligible_due_to_immigration_only?(thhm)
         ineligibility_reasons = thhm[:product_eligibility_determination][:magi_medicaid_ineligibility_reasons]
         ineligibility_reasons&.include?("Applicant did not meet citizenship/immigration requirements") && ineligibility_reasons.count == 1
       end
 
-      def only_chip_ineligible_due_to_immigration?(thhm)
+      def chip_ineligible_due_to_immigration_only?(thhm)
         ineligibility_reasons = thhm[:product_eligibility_determination][:chip_ineligibility_reasons]
         ineligibility_reasons&.include?("Applicant did not meet citizenship/immigration requirements") && ineligibility_reasons.count == 1
       end
 
-      def construct_member_determination_object(determ_reason)
-        [{
-          kind: 'Medicaid/CHIP Determination',
-          is_eligible: true,
-          determination_reasons: [determ_reason]
-        }]
+      def member_determ_for(thhm, determ_reason)
+        member_determs = thhm.dig(:product_eligibility_determination, :member_determinations)
+        mdc_chip_determ = member_determs&.detect {|md| md[:kind] == 'Medicaid/CHIP Determination' }
+        if mdc_chip_determ.present?
+          mdc_chip_determ[:determination_reasons] << determ_reason
+        else
+          {
+            kind: 'Medicaid/CHIP Determination',
+            is_eligible: true,
+            determination_reasons: [determ_reason]
+          }
+        end
       end
     end
   end

--- a/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
+++ b/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
@@ -52,7 +52,12 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
         totally_ineligible: false,
         uqhp_eligible: false,
         csr_eligible: true,
-        csr: '73' }
+        csr: '73',
+        member_determination: [{
+          kind: 'Insurance Assistance Determination',
+          is_eligible: true,
+          determination_reasons: [:income_above_threshold]
+        }] }
     end
 
     before { @result = subject.call(input_params) }
@@ -92,7 +97,12 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
           totally_ineligible: true,
           uqhp_eligible: false,
           csr_eligible: true,
-          csr: '73' }
+          csr: '73',
+          member_determination: [{
+            kind: 'Insurance Assistance Determination',
+            is_eligible: true,
+            determination_reasons: [:income_above_threshold]
+          }] }
       end
 
       before do
@@ -117,7 +127,12 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
           totally_ineligible: false,
           uqhp_eligible: false,
           csr_eligible: true,
-          csr: nil }
+          csr: nil,
+          member_determination: [{
+            kind: 'Insurance Assistance Determination',
+            is_eligible: true,
+            determination_reasons: [:income_above_threshold]
+          }] }
       end
 
       before do

--- a/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
+++ b/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
         uqhp_eligible: false,
         csr_eligible: true,
         csr: '73',
-        member_determination: [{
+        member_determinations: [{
           kind: 'Insurance Assistance Determination',
           is_eligible: true,
           determination_reasons: [:income_above_threshold]
@@ -98,7 +98,7 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
           uqhp_eligible: false,
           csr_eligible: true,
           csr: '73',
-          member_determination: [{
+          member_determinations: [{
             kind: 'Insurance Assistance Determination',
             is_eligible: true,
             determination_reasons: [:income_above_threshold]

--- a/spec/contracts/aptc_csr/member_contract_spec.rb
+++ b/spec/contracts/aptc_csr/member_contract_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe ::AptcCsr::MemberContract, dbclean: :around_each do
       totally_ineligible: false,
       uqhp_eligible: false,
       csr_eligible: true,
-      csr: '73' }
+      csr: '73',
+      member_determination: [{
+        kind: 'Insurance Assistance Determination',
+        is_eligible: true,
+        determination_reasons: [:income_above_threshold]
+      }] }
   end
 
   let(:all_params) do

--- a/spec/contracts/aptc_csr/member_contract_spec.rb
+++ b/spec/contracts/aptc_csr/member_contract_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ::AptcCsr::MemberContract, dbclean: :around_each do
       uqhp_eligible: false,
       csr_eligible: true,
       csr: '73',
-      member_determination: [{
+      member_determinations: [{
         kind: 'Insurance Assistance Determination',
         is_eligible: true,
         determination_reasons: [:income_above_threshold]

--- a/spec/factories/aptc_household_members.rb
+++ b/spec/factories/aptc_household_members.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     annual_household_income_contribution { 10_000.89 }
     tax_filer_status { 'tax_filer' }
     is_applicant { true }
+    age_of_applicant { 20 }
     benchmark_plan_monthly_premium_amount { 355.5 }
     aptc_eligible { true }
     totally_ineligible { false }

--- a/spec/factories/aptc_household_members.rb
+++ b/spec/factories/aptc_household_members.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     csr_eligible { true }
     csr { '73' }
 
-    member_determination do
+    member_determinations do
       [{
         kind: 'Insurance Assistance Determination',
         is_eligible: true,

--- a/spec/factories/aptc_household_members.rb
+++ b/spec/factories/aptc_household_members.rb
@@ -2,9 +2,8 @@
 
 FactoryBot.define do
   factory :aptc_household_member, class: "::Medicaid::AptcHouseholdMember" do
-    aptc_household
 
-    sequence(:member_identifier) { |n| "20000#{n}" }
+    sequence(:member_identifier) { |n| "30000#{n}" }
     household_count { 1 }
     annual_household_income_contribution { 10_000.89 }
     tax_filer_status { 'tax_filer' }
@@ -15,5 +14,14 @@ FactoryBot.define do
     uqhp_eligible { false }
     csr_eligible { true }
     csr { '73' }
+
+    member_determination do
+      [{
+        kind: 'Insurance Assistance Determination',
+        is_eligible: true,
+        determination_reasons: [:income_above_threshold]
+      }]
+    end
+
   end
 end

--- a/spec/factories/aptc_households.rb
+++ b/spec/factories/aptc_households.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :aptc_household, class: "::Medicaid::AptcHousehold" do
-    application
 
+  factory :aptc_household, class: "::Medicaid::AptcHousehold" do
+    sequence(:_id) { |n| "20000#{n}" }
     total_household_count { 1 }
     annual_tax_household_income { 10_000.89 }
     is_aptc_calculated { true }
@@ -24,15 +24,13 @@ FactoryBot.define do
         aptc_effective_end_on: Date.new(Date.today.year + 1, 10, 31) }
     end
 
+    aptc_household_members do
+      [FactoryBot.build(:aptc_household_member)]
+    end
+
     tax_household_identifier { '192837465' }
     fpl_percent { 256.00 }
     eligibility_date { Date.today.next_month.beginning_of_month }
-
-    trait :with_aptc_household_members do
-      aptc_household_members do
-        [FactoryBot.build(:aptc_household_member)]
-      end
-    end
 
     trait :with_benchmark_calculation_members do
       benchmark_calculation_members do

--- a/spec/factories/benchmark_calculation_members.rb
+++ b/spec/factories/benchmark_calculation_members.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :benchmark_calculation_member, class: "::Medicaid::BenchmarkCalculationMember" do
-    aptc_household
 
     sequence(:member_identifier) { |n| "20000#{n}" }
     relationship_kind_to_primary { 'self' }

--- a/spec/models/medicaid/aptc_household_member_spec.rb
+++ b/spec/models/medicaid/aptc_household_member_spec.rb
@@ -3,31 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe ::Medicaid::AptcHouseholdMember, type: :model, dbclean: :after_each do
-  context 'embeds_many :member_determinations' do
-    before do
-      @association = described_class.reflect_on_association(:member_determinations)
-    end
-
-    it "should return association's class as EmbedsMany" do
-      expect(@association.class).to eq(Mongoid::Association::Embedded::EmbedsMany)
-    end
-
-    it "should return association's name as member_determinations" do
-      expect(@association.name).to eq(:member_determinations)
-    end
-  end
-
-  context 'valid params' do
+  context 'with valid params' do
     let(:application) { FactoryBot.create(:application, :with_aptc_households) }
 
     before do
       application.save!
       @app = application
-    end
-
-    it 'should be saved correctly' do
-      member = Medicaid::Application.find(@app.id).aptc_households.first.aptc_household_members.first
-      expect(member).to be_a(::Medicaid::AptcHouseholdMember)
     end
 
     it 'should not return nil for determination_reasons attribute' do

--- a/spec/models/medicaid/aptc_household_member_spec.rb
+++ b/spec/models/medicaid/aptc_household_member_spec.rb
@@ -21,17 +21,18 @@ RSpec.describe ::Medicaid::AptcHouseholdMember, type: :model, dbclean: :after_ea
     let(:application) { FactoryBot.create(:application, :with_aptc_households) }
 
     before do
-      @aptc_hh_member = application.aptc_households.first.aptc_household_members.first
-      ## when i save the application, the child aptc_household and aptc_household_members arent saving => i cant query for them in the 'find()'s below
       application.save!
+      @app = application
     end
 
-    pending 'should be findable' do
-      expect(described_class.find(@aptc_hh_member.id)).to be_a(::Medicaid::AptcHouseholdMember)
+    it 'should be saved correctly' do
+      member = Medicaid::Application.find(@app.id).aptc_households.first.aptc_household_members.first
+      expect(member).to be_a(::Medicaid::AptcHouseholdMember)
     end
 
-    pending 'should not return nil for determination_reasons attribute' do
-      expect(described_class.find(@aptc_hh_member.id).determination_reasons).to not_eq nil
+    it 'should not return nil for determination_reasons attribute' do
+      member = Medicaid::Application.find(@app.id).aptc_households.first.aptc_household_members.first
+      expect(member.member_determinations).to_not eq nil
     end
   end
 end

--- a/spec/models/medicaid/aptc_household_member_spec.rb
+++ b/spec/models/medicaid/aptc_household_member_spec.rb
@@ -2,18 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe ::Medicaid::AptcHouseholdMember, type: :model do
-  context 'embeds_many :member_determination' do
+RSpec.describe ::Medicaid::AptcHouseholdMember, type: :model, dbclean: :after_each do
+  context 'embeds_many :member_determinations' do
     before do
-      @association = described_class.reflect_on_association(:member_determination)
+      @association = described_class.reflect_on_association(:member_determinations)
     end
 
     it "should return association's class as EmbedsMany" do
       expect(@association.class).to eq(Mongoid::Association::Embedded::EmbedsMany)
     end
 
-    it "should return association's name as member_determination" do
-      expect(@association.name).to eq(:member_determination)
+    it "should return association's name as member_determinations" do
+      expect(@association.name).to eq(:member_determinations)
     end
   end
 

--- a/spec/models/medicaid/aptc_household_member_spec.rb
+++ b/spec/models/medicaid/aptc_household_member_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Medicaid::AptcHouseholdMember, type: :model do
+  context 'embeds_many :member_determination' do
+    before do
+      @association = described_class.reflect_on_association(:member_determination)
+    end
+
+    it "should return association's class as EmbedsMany" do
+      expect(@association.class).to eq(Mongoid::Association::Embedded::EmbedsMany)
+    end
+
+    it "should return association's name as member_determination" do
+      expect(@association.name).to eq(:member_determination)
+    end
+  end
+
+  context 'valid params' do
+    let(:application) { FactoryBot.create(:application, :with_aptc_households) }
+
+    before do
+      @aptc_hh_member = application.aptc_households.first.aptc_household_members.first
+      ## when i save the application, the child aptc_household and aptc_household_members arent saving => i cant query for them in the 'find()'s below
+      application.save!
+    end
+
+    pending 'should be findable' do
+      expect(described_class.find(@aptc_hh_member.id)).to be_a(::Medicaid::AptcHouseholdMember)
+    end
+
+    pending 'should not return nil for determination_reasons attribute' do
+      expect(described_class.find(@aptc_hh_member.id).determination_reasons).to not_eq nil
+    end
+  end
+end

--- a/spec/models/medicaid/aptc_household_spec.rb
+++ b/spec/models/medicaid/aptc_household_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ::Medicaid::AptcHousehold, type: :model do
+RSpec.describe ::Medicaid::AptcHousehold, type: :model, dbclean: :after_each do
   context 'associations' do
     context 'embeds_many :benchmark_calculation_members' do
       before do

--- a/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
+++ b/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
@@ -145,7 +145,8 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
         magi_medicaid_monthly_income_limit: 3760.67,
         magi_as_percentage_of_fpl: 10.0,
         magi_medicaid_category: "parent_caretaker",
-        chip_ineligibility_reasons: ["Applicant did not meet citizenship/immigration requirements"] }
+        chip_ineligibility_reasons: ["Applicant did not meet citizenship/immigration requirements"],
+        magi_medicaid_ineligibility_reasons: ["Applicant did not meet citizenship/immigration requirements"] }
     end
 
     let(:input_application) do

--- a/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
+++ b/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
@@ -9,7 +9,9 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
     { citizen_status: "not_lawfully_present_in_us",
       is_lawful_presence_self_attested: false }
   end
+
   include_context "setup magi_medicaid application with two applicants"
+
   context "with applicant over 18 not lawfully present" do
     let(:product_eligibility_determination2) do
       { is_ia_eligible: false,
@@ -128,24 +130,64 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
         expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_under_twenty_one)
       end
     end
+  end
 
-    context "with applicant not lawfully present and 18 or under" do
-      let(:product_eligibility_determination3) do
-        { is_ia_eligible: false,
-          is_medicaid_chip_eligible: false,
-          is_non_magi_medicaid_eligible: false,
-          is_totally_ineligible: false,
-          is_without_assistance: false,
-          is_magi_medicaid: false,
-          magi_medicaid_monthly_household_income: 6474.42,
-          medicaid_household_size: 1,
-          magi_medicaid_monthly_income_limit: 3760.67,
-          magi_as_percentage_of_fpl: 10.0,
-          magi_medicaid_category: "parent_caretaker",
-          chip_ineligibility_reasons: ["Applicant did not meet citizenship/immigration requirements"] }
+  context "with applicant not lawfully present and 18 or under" do
+    let(:product_eligibility_determination3) do
+      { is_ia_eligible: false,
+        is_medicaid_chip_eligible: false,
+        is_non_magi_medicaid_eligible: false,
+        is_totally_ineligible: false,
+        is_without_assistance: false,
+        is_magi_medicaid: false,
+        magi_medicaid_monthly_household_income: 6474.42,
+        medicaid_household_size: 1,
+        magi_medicaid_monthly_income_limit: 3760.67,
+        magi_as_percentage_of_fpl: 10.0,
+        magi_medicaid_category: "parent_caretaker",
+        chip_ineligibility_reasons: ["Applicant did not meet citizenship/immigration requirements"] }
+    end
+
+    let(:input_application) do
+      app_params = mm_application_entity.to_h
+      app_params[:applicants].first[:age_of_applicant] = 18
+      app_params[:applicants].first[:citizenship_immigration_status_information] = citizenship_immigration_status_information2
+      app_params[:tax_households].first[:tax_household_members].first[:product_eligibility_determination] = product_eligibility_determination3
+      ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(app_params).success
+    end
+
+    let(:input_params) do
+      { magi_medicaid_application: input_application }
+    end
+
+    before do
+      chip_override_flag = MedicaidGatewayRegistry[:eligibility_override].setting(:mitc_override_not_lawfully_present_chip_eligible)
+      allow(chip_override_flag).to receive(:item).and_return("true")
+      pregnant_override_flag = MedicaidGatewayRegistry[:eligibility_override].setting(:mitc_override_not_lawfully_present_pregnant)
+      allow(pregnant_override_flag).to receive(:item).and_return("true")
+      @result = subject.call(input_params)
+    end
+
+    it "should return chip eligible" do
+      chip_eligible = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_medicaid_chip_eligible
+      expect(chip_eligible).to eq(true)
+    end
+
+    it "should return member_determination determiation_reason :mitc_override_not_lawfully_present_chip_eligible" do
+      member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
+      expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_chip_eligible)
+    end
+
+    context "and pregnant" do
+      let(:pregnancy_information2) do
+        { is_pregnant: true,
+          is_post_partum_period: false,
+          expected_children_count: 1,
+          pregnancy_due_on: Date.today.next_month }
       end
       let(:input_application) do
         app_params = mm_application_entity.to_h
+        app_params[:applicants].first[:pregnancy_information] = pregnancy_information2
         app_params[:applicants].first[:age_of_applicant] = 18
         app_params[:applicants].first[:citizenship_immigration_status_information] = citizenship_immigration_status_information2
         app_params[:tax_households].first[:tax_household_members].first[:product_eligibility_determination] = product_eligibility_determination3
@@ -157,20 +199,28 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
       end
 
       before do
-        chip_override_flag = MedicaidGatewayRegistry[:eligibility_override].setting(:mitc_override_not_lawfully_present_chip_eligible)
-        allow(chip_override_flag).to receive(:item).and_return("true")
         @result = subject.call(input_params)
       end
 
-      it "should return chip eligible" do
-        chip_eligible = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_medicaid_chip_eligible
-        expect(chip_eligible).to eq(true)
+      it "should return success" do
+        expect(@result).to be_success
       end
 
-      it "should return member_determination determiation_reason :mitc_override_not_lawfully_present_chip_eligible" do
+      it "should return a MagiMedicaidApplication entity" do
+        expect(@result.success).to be_a(::AcaEntities::MagiMedicaid::Application)
+      end
+
+      it "should return chip eligible" do
+        member = @result.success.tax_households.first.tax_household_members.first
+        expect(member.product_eligibility_determination.is_medicaid_chip_eligible).to eq(true)
+      end
+
+      it "should return member_determination with multiple determiation_reasons" do
         member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
-        expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_chip_eligible)
+        expected_array = [:mitc_override_not_lawfully_present_pregnant, :mitc_override_not_lawfully_present_chip_eligible]
+        expect(member_determs.first.determination_reasons).to match_array(expected_array)
       end
     end
   end
+
 end

--- a/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
+++ b/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
@@ -55,6 +55,7 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
         expect(@result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_magi_medicaid).to eq(false)
       end
     end
+
     context "with pregnant applicant 21 or over" do
       let(:pregnancy_information2) do
         { is_pregnant: true,
@@ -92,7 +93,13 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
       it "should return medicaid eligible" do
         expect(@result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_magi_medicaid).to eq(true)
       end
+
+      it "should return member_determination determiation_reason :mitc_override_not_lawfully_present_pregnant" do
+        member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
+        expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_pregnant)
+      end
     end
+
     context "with applicant 19-20 and not pregnant" do
       let(:input_application) do
         app_params = mm_application_entity.to_h
@@ -114,6 +121,11 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
 
       it "should return medicaid eligible" do
         expect(@result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_magi_medicaid).to eq(true)
+      end
+
+      it "should return member_determination determiation_reason :mitc_override_not_lawfully_present_under_twenty_one" do
+        member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
+        expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_under_twenty_one)
       end
     end
 
@@ -153,6 +165,11 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
       it "should return chip eligible" do
         chip_eligible = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.is_medicaid_chip_eligible
         expect(chip_eligible).to eq(true)
+      end
+
+      it "should return member_determination determiation_reason :mitc_override_not_lawfully_present_chip_eligible" do
+        member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
+        expect(member_determs.first.determination_reasons.first).to eq(:mitc_override_not_lawfully_present_chip_eligible)
       end
     end
   end

--- a/spec/operations/eligibilities/aptc_csr/calculate_benchmark_plan_amount_spec.rb
+++ b/spec/operations/eligibilities/aptc_csr/calculate_benchmark_plan_amount_spec.rb
@@ -16,41 +16,47 @@ describe Eligibilities::AptcCsr::CalculateBenchmarkPlanAmount do
     end
 
     let(:input_params) do
-      { aptc_household: { :members =>
-       [{ :member_identifier => "95",
-          :household_count => 1,
-          :tax_filer_status => "tax_filer",
-          :is_applicant => true,
-          :age_of_applicant => 45,
-          :annual_household_income_contribution => 0.0,
-          :aptc_eligible => true,
-          :csr_eligible => true,
-          :benchmark_plan_monthly_premium_amount => 320.53 },
-        { :member_identifier => "96",
-          :household_count => 1,
-          :tax_filer_status => "tax_filer",
-          :is_applicant => true,
-          :age_of_applicant => 43,
-          :annual_household_income_contribution => 0.0,
-          :aptc_eligible => true,
-          :csr_eligible => true,
-          :benchmark_plan_monthly_premium_amount => 320.63 }],
-                          :assistance_year => 2021,
-                          :total_household_count => 1,
-                          :annual_tax_household_income => 0.0,
-                          :eligibility_date => Date.today,
-                          :fpl_percent => 0.0,
-                          :fpl =>
-       { :state_code => "DC",
-         :household_size => 2,
-         :medicaid_year => 2021,
-         :annual_poverty_guideline => 12_765.0,
-         :annual_per_person_amount => 4484.0,
-         :monthly_poverty_guideline => 1063.0,
-         :monthly_per_person_amount => 374.0,
-         :aptc_effective_start_on => Date.today,
-         :aptc_effective_end_on => Date.today },
-                          :total_expected_contribution_amount => 0.0 },
+      { aptc_household:
+        { :members =>
+          [{
+            :member_identifier => "95",
+            :household_count => 1,
+            :tax_filer_status => "tax_filer",
+            :is_applicant => true,
+            :age_of_applicant => 45,
+            :annual_household_income_contribution => 0.0,
+            :aptc_eligible => true,
+            :csr_eligible => true,
+            :benchmark_plan_monthly_premium_amount => 320.53
+          }, {
+            :member_identifier => "96",
+            :household_count => 1,
+            :tax_filer_status => "tax_filer",
+            :is_applicant => true,
+            :age_of_applicant => 43,
+            :annual_household_income_contribution => 0.0,
+            :aptc_eligible => true,
+            :csr_eligible => true,
+            :benchmark_plan_monthly_premium_amount => 320.63
+          }],
+          :assistance_year => 2021,
+          :total_household_count => 1,
+          :annual_tax_household_income => 0.0,
+          :eligibility_date => Date.today,
+          :fpl_percent => 0.0,
+          :fpl =>
+            {
+              :state_code => "DC",
+              :household_size => 2,
+              :medicaid_year => 2021,
+              :annual_poverty_guideline => 12_765.0,
+              :annual_per_person_amount => 4484.0,
+              :monthly_poverty_guideline => 1063.0,
+              :monthly_per_person_amount => 374.0,
+              :aptc_effective_start_on => Date.today,
+              :aptc_effective_end_on => Date.today
+            },
+          :total_expected_contribution_amount => 0.0 },
         tax_household: input_tax_household,
         application: mm_application_entity }
     end


### PR DESCRIPTION
[TT6-185060667](https://www.pivotaltracker.com/story/show/185060667)

- adds member_determination model/entities
- sets and saves the memeber_determination fields as part of the override flow

