### PR TITLE
Mock 2024 Eligibility Settings

### DIFF
--- a/components/mitc_service/spec/dummy/app/models/types.rb
+++ b/components/mitc_service/spec/dummy/app/models/types.rb
@@ -75,6 +75,12 @@ module Types
       medicaid_year: 2023,
       annual_poverty_guideline: BigDecimal(13_590.to_s),
       annual_per_person_amount: BigDecimal(4_720.to_s)
+    },
+    # adding 2024 values as placeholders to placate specs. These values are not verified.
+    {
+      medicaid_year: 2024,
+      annual_poverty_guideline: BigDecimal(13_590.to_s),
+      annual_per_person_amount: BigDecimal(4_720.to_s)
     }
   ].freeze
 
@@ -103,6 +109,13 @@ module Types
         earned_income: BigDecimal('12_400'),
         unearned_income: BigDecimal('1_100')
       }
+    },
+    # adding 2024 values as placeholders to placate specs. These values are not verified.
+    {
+      2024 => {
+        earned_income: BigDecimal('12_400'),
+        unearned_income: BigDecimal('1_100')
+      }
     }
   ].freeze
 
@@ -111,7 +124,9 @@ module Types
     { 2020 => BigDecimal('9.83') },
     { 2021 => BigDecimal('9.83') },
     { 2022 => BigDecimal('9.61') },
-    { 2023 => BigDecimal('9.12') }
+    { 2023 => BigDecimal('9.12') },
+    # adding 2024 values as placeholders to placate specs. These values are not verified.
+    { 2024 => BigDecimal('9.12') }
   ].freeze
 
   CsrKind = Types::Coercible::String.enum('0',


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185261989

This PR is to mock values for 2024 eligibility settings.

We need these amounts

- annual_poverty_guideline 
- annual_per_person_amount
- affordability percentage for 2024 


Update these fields when we get this data 

app/models/types.rb:131
components/mitc_service/spec/dummy/app/models/types.rb:79
components/mitc_service/spec/dummy/app/models/types.rb:113
components/mitc_service/spec/dummy/app/models/types.rb:121