### PR TITLE
add eligibility override enhancements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: e9cb75a9b3273152f01d26b3ae87c1114b53ccd7
+  revision: bcc958349ef439b7f53f06bcad26a25e8e0b89ef
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/contracts/aptc_csr/eligibility_override_contract.rb
+++ b/app/contracts/aptc_csr/eligibility_override_contract.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'types'
+
+module AptcCsr
+  # Schema and validation rules for {AptcCsr::EligibilityOverrideContract}
+  class EligibilityOverrideContract < Dry::Validation::Contract
+    # @!method call(opts)
+    # @param [Hash] opts the parameters to validate using this contract
+    # @return [Dry::Monads::Result]
+    params do
+      required(:override_rule).filled(Types::EligibilityOverrideRule)
+      required(:override_applied).filled(:bool)
+    end
+  end
+end

--- a/app/contracts/aptc_csr/member_determination_contract.rb
+++ b/app/contracts/aptc_csr/member_determination_contract.rb
@@ -9,9 +9,10 @@ module AptcCsr
     # @param [Hash] opts the parameters to validate using this contract
     # @return [Dry::Monads::Result]
     params do
-      optional(:kind).maybe(Types::MemberDeterminationKind)
-      optional(:is_eligible).maybe(:bool)
-      optional(:determination_reasons).array(::Types::Symbol)
+      required(:kind).filled(Types::MemberDeterminationKind)
+      required(:criteria_met).filled(:bool)
+      required(:determination_reasons).array(::Types::Symbol)
+      required(:eligibility_overrides).array(AptcCsr::EligibilityOverrideContract.params)
     end
   end
 end

--- a/app/entities/aptc_csr/eligibility_override.rb
+++ b/app/entities/aptc_csr/eligibility_override.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AptcCsr
+  # An entity to represent a EligibilityOverride
+  class EligibilityOverride < Dry::Struct
+
+    attribute :override_rule, Types::EligibilityOverrideRule
+    attribute :override_applied, Types::Bool
+
+  end
+end

--- a/app/entities/aptc_csr/member_determination.rb
+++ b/app/entities/aptc_csr/member_determination.rb
@@ -5,8 +5,9 @@ module AptcCsr
   class MemberDetermination < Dry::Struct
 
     attribute :kind, Types::MemberDeterminationKind
-    attribute :is_eligible, Types::Bool
-    attribute :determination_reasons, Types::Array.of(Types::Symbol).optional.meta(omittable: true)
+    attribute :criteria_met, Types::Bool
+    attribute :determination_reasons, Types::Array.of(Types::Symbol)
+    attribute :eligibility_overrides, Types::Array.of(AptcCsr::EligibilityOverride)
 
   end
 end

--- a/app/models/medicaid/eligibility_override.rb
+++ b/app/models/medicaid/eligibility_override.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Medicaid
+  # Represents an eligibility override for a member
+  class EligibilityOverride
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    # The override rule that was applied.
+    field :override_rule, type: Symbol
+
+    # Whether or not the override was applied.
+    field :override_applied, type: Boolean
+
+    embedded_in :member_determination, class_name: '::Medicaid::MemberDetermination'
+
+  end
+end

--- a/app/models/medicaid/member_determination.rb
+++ b/app/models/medicaid/member_determination.rb
@@ -10,12 +10,12 @@ module Medicaid
     field :kind, type: String
 
     # Whether or not the member is eligible for the kind of determination.
-    field :is_eligible, type: Boolean
+    field :criteria_met, type: Boolean
 
     # the reasons the member qualifies for the determination.
     field :determination_reasons, type: Array
 
     embedded_in :aptc_household_member, class_name: '::Medicaid::AptcHouseholdMember'
-
+    embeds_many :eligibility_overrides, class_name: '::Medicaid::EligibilityOverride'
   end
 end

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -173,4 +173,9 @@ module Types
     'Total Ineligibility Determination'
   )
 
+  EligibilityOverrideRule = Types::Coercible::Symbol.enum(
+    :not_lawfully_present_pregnant,
+    :not_lawfully_present_chip_eligible,
+    :not_lawfully_present_under_twenty_one
+  )
 end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -38,19 +38,19 @@ module Eligibilities
       end
 
       def apply_eligibility_overrides(app_with_member_determs)
+        # loop through each member and update the member_determination if override rule is applicable
         app_with_member_determs[:tax_households].each do |mm_thh|
           mm_thh[:tax_household_members].each do |thhm|
-            ped = thhm[:product_eligibility_determination]
-            ped[:member_determinations] ||= [medicaid_chip_member_determination]
             @override_rules.each do |rule|
-              apply_override_rule(thhm, ped, rule)
+              apply_override_rule(thhm, rule)
             end
           end
         end
         ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(app_with_member_determs)
       end
 
-      def apply_override_rule(thhm, ped, rule)
+      def apply_override_rule(thhm, rule)
+        ped = thhm[:product_eligibility_determination]
         case rule
         when :not_lawfully_present_pregnant
           if medicaid_ineligible_due_to_immigration_only?(thhm) && pregnancy_override?(thhm)
@@ -126,7 +126,6 @@ module Eligibilities
         mdc_chip_determ[:criteria_met] = true
         mdc_chip_determ[:determination_reasons] << rule
         set_override_rule_applied(mdc_chip_determ[:eligibility_overrides], rule)
-        mdc_chip_determ
       end
 
       def set_override_rule_applied(overrides, rule)

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -9,77 +9,65 @@ module Eligibilities
     class ApplyEligibilityOverrides
       include Dry::Monads[:result, :do]
 
-      # params are mm_app_with_member_determinations
+      # @params [Hash] opts The options to apply eligibility overrides
+      # @option opts [AcaEntities::MagiMedicaid::Application] :magi_medicaid_application
+      # @return [Dry::Result]
       def call(params)
-        # @override_rules = ::AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule.values.map(&:to_sym)
-        @override_rules = [:not_lawfully_present_pregnant, :not_lawfully_present_chip_eligible, :not_lawfully_present_under_twenty_one]
+        @override_rules = ::AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule.values
         valid_params = yield validate_params(params)
         app_with_member_determs = yield add_mdc_chip_member_determs(valid_params)
         result = yield apply_eligibility_overrides(app_with_member_determs)
         Success(result)
       end
+
       def validate_params(params)
         return Success(params) if params[:magi_medicaid_application].present?
         Failure("Invalid params -- magi_medicaid_application is missing in: #{params}")
       end
 
       def add_mdc_chip_member_determs(params)
-        mm_application = params[:magi_medicaid_application]
-        @mm_app_hash = mm_application.to_h
-        @mm_app_hash[:tax_households].each do |mm_thh|
+        @mm_application = params[:magi_medicaid_application]
+        mm_app_hash = @mm_application.to_h
+        mm_app_hash[:tax_households].each do |mm_thh|
           mm_thh[:tax_household_members].each do |thhm|
             ped = thhm[:product_eligibility_determination]
             ped[:member_determinations] = [medicaid_chip_member_determination]
           end
         end
+        Success(mm_app_hash)
       end
 
       def apply_eligibility_overrides(app_with_member_determs)
-        # @mm_application = params[:magi_medicaid_application]
-        # mm_app_hash = @mm_application.to_h
         app_with_member_determs[:tax_households].each do |mm_thh|
           mm_thh[:tax_household_members].each do |thhm|
             ped = thhm[:product_eligibility_determination]
             ped[:member_determinations] ||= [medicaid_chip_member_determination]
-
             @override_rules.each do |rule|
-              case rule
-              when :not_lawfully_present_pregnant
-                if medicaid_ineligible_due_to_immigration_only?(thhm) && pregnancy_override?(thhm)
-                  ped[:is_magi_medicaid] = true
-                  update_member_determ_for(thhm, rule)
-                end
-              when :not_lawfully_present_under_twenty_one
-                if medicaid_ineligible_due_to_immigration_only?(thhm) && nineteen_to_twenty_one_override?(thhm)
-                  ped[:is_magi_medicaid] = true
-                  update_member_determ_for(thhm, rule)
-                end
-              when :not_lawfully_present_chip_eligible
-                if medicaid_ineligible_due_to_immigration_only?(thhm) && under_eighteen_chip_override?(thhm)
-                  ped[:is_medicaid_chip_eligible] = true
-                  update_member_determ_for(thhm, rule)
-                end
-              end
-
-              # if medicaid_ineligible_due_to_immigration_only?(thhm)
-              #   if pregnancy_override?(thhm)
-              #     ped[:is_magi_medicaid] = true
-              #     # ped[:member_determinations] << member_determ_for(thhm, rule)
-              #     ped[:member_determinations] << update_member_determ_for(thhm, rule)
-              #   end
-              #   if nineteen_to_twenty_one_override?(thhm)
-              #     ped[:is_magi_medicaid] = true
-              #     ped[:member_determinations] << member_determ_for(thhm, rule)
-              #   end
-              # end
-              # if chip_ineligible_due_to_immigration_only?(thhm) && under_eighteen_chip_override?(thhm)
-              #   ped[:is_medicaid_chip_eligible] = true
-              #   ped[:member_determinations] << member_determ_for(thhm, rule)
-              # end
+              apply_override_rule(thhm, ped, rule)
             end
           end
         end
         ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(app_with_member_determs)
+      end
+
+      def apply_override_rule(thhm, ped, rule)
+        case rule
+        when :not_lawfully_present_pregnant
+          if medicaid_ineligible_due_to_immigration_only?(thhm) && pregnancy_override?(thhm)
+            ped[:is_magi_medicaid] = true
+            update_member_determ_for(thhm, rule)
+          end
+        when :not_lawfully_present_under_twenty_one
+          if medicaid_ineligible_due_to_immigration_only?(thhm) && nineteen_to_twenty_one_override?(thhm)
+            ped[:is_magi_medicaid] = true
+            update_member_determ_for(thhm, rule)
+          end
+        when :not_lawfully_present_chip_eligible
+          if medicaid_ineligible_due_to_immigration_only?(thhm) && under_eighteen_chip_override?(thhm)
+            ped[:is_medicaid_chip_eligible] = true
+            update_member_determ_for(thhm, rule)
+          end
+        end
       end
 
       def pregnancy_override?(thhm)
@@ -114,43 +102,36 @@ module Eligibilities
         ineligibility_reasons&.include?("Applicant did not meet citizenship/immigration requirements") && ineligibility_reasons.count == 1
       end
 
-      def member_determ_for(thhm, determ_reason)
-        member_determs = thhm.dig(:product_eligibility_determination, :member_determinations)
-        mdc_chip_determ = member_determs&.detect {|md| md[:kind] == 'Medicaid/CHIP Determination' }
-        if mdc_chip_determ.present?
-          mdc_chip_determ[:determination_reasons] << determ_reason
-        else
-          {
-            kind: 'Medicaid/CHIP Determination',
-            is_eligible: true,
-            determination_reasons: [determ_reason]
-          }
-        end
-      end
-
       def medicaid_chip_member_determination
         {
           kind: 'Medicaid/CHIP Determination',
-          is_eligible: false,
+          criteria_met: false,
           determination_reasons: [],
-          override_rules: []
+          eligibility_overrides: eligibility_overrides
         }
+      end
+
+      def eligibility_overrides
+        @override_rules.map do |rule|
+          {
+            override_rule: rule,
+            override_applied: false
+          }
+        end
       end
 
       def update_member_determ_for(thhm, rule)
         member_determs = thhm.dig(:product_eligibility_determination, :member_determinations)
         mdc_chip_determ = member_determs&.detect {|md| md[:kind] == 'Medicaid/CHIP Determination' }
-        mdc_chip_determ[:is_eligible] = true
+        mdc_chip_determ[:criteria_met] = true
         mdc_chip_determ[:determination_reasons] << rule
-        mdc_chip_determ[:override_rules] << set_override_rule(rule, true)
+        set_override_rule_applied(mdc_chip_determ[:eligibility_overrides], rule)
         mdc_chip_determ
       end
 
-      def set_override_rule(rule, value)
-        {
-          override_rule: rule,
-          override_applied: value
-        }
+      def set_override_rule_applied(overrides, rule)
+        override = overrides.detect {|ov| ov[:override_rule] == rule }
+        override[:override_applied] = true
       end
     end
   end

--- a/app/operations/eligibilities/aptc_csr/determine_other_eligibilities.rb
+++ b/app/operations/eligibilities/aptc_csr/determine_other_eligibilities.rb
@@ -47,8 +47,9 @@ module Eligibilities
           aptc_member[:member_determinations] ||= []
           aptc_member[:member_determinations] << {
             kind: 'Total Ineligibility Determination',
-            is_eligible: false,
-            determination_reasons: totally_ineligible_reasons
+            criteria_met: false,
+            determination_reasons: totally_ineligible_reasons,
+            eligibility_overrides: []
           }
         else
           aptc_member[:uqhp_eligible] = true

--- a/components/mitc_service/Gemfile.lock
+++ b/components/mitc_service/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: ab7af7e162fbd2a0a48e3961352f02817fa83033
+  revision: bcc958349ef439b7f53f06bcad26a25e8e0b89ef
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/components/mitc_service/spec/operations/mitc_service/add_mitc_determination_to_application_spec.rb
+++ b/components/mitc_service/spec/operations/mitc_service/add_mitc_determination_to_application_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe ::MitcService::AddMitcDeterminationToApplication do
     { magi_medicaid_application: mm_application, mitc_response: mitc_response }
   end
 
+  let(:override_rules) { ::AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule.values }
+
   it 'should be a container-ready operation' do
     expect(subject.respond_to?(:call)).to be_truthy
   end
@@ -29,6 +31,28 @@ RSpec.describe ::MitcService::AddMitcDeterminationToApplication do
 
     it 'should return the MagiMedicaidApplication entity' do
       expect(@result.success).to be_a(::AcaEntities::MagiMedicaid::Application)
+    end
+
+    context "member determinations" do
+
+      it "should create only one member determination object for medicaid/chip eligibility for each member" do
+        @result.success.tax_households.first.tax_household_members.each do |member|
+          member_determinations = member.product_eligibility_determination.member_determinations
+          expect(member_determinations.count).to eq(1)
+          expect(member_determinations.first.kind).to eq("Medicaid/CHIP Determination")
+          expect(member_determinations.first).to be_a(::AcaEntities::MagiMedicaid::MemberDetermination)
+        end
+      end
+
+      it "should create an override object for each override rule" do
+        member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
+        eligibility_overrides = member_determs.first.eligibility_overrides
+        expect(eligibility_overrides.count).to eq(override_rules.count)
+        override_rules.each do |rule|
+          eligibility_override = eligibility_overrides.detect { |override| override.override_rule == rule }
+          expect(eligibility_override.present?).to be_truthy
+        end
+      end
     end
   end
 

--- a/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
+++ b/spec/contracts/aptc_csr/aptc_household_contract_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
         csr: '73',
         member_determinations: [{
           kind: 'Insurance Assistance Determination',
-          is_eligible: true,
-          determination_reasons: [:income_above_threshold]
+          criteria_met: true,
+          determination_reasons: [:income_above_threshold],
+          eligibility_overrides: []
         }] }
     end
 
@@ -100,8 +101,9 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
           csr: '73',
           member_determinations: [{
             kind: 'Insurance Assistance Determination',
-            is_eligible: true,
-            determination_reasons: [:income_above_threshold]
+            criteria_met: true,
+            determination_reasons: [:income_above_threshold],
+            eligibility_overrides: []
           }] }
       end
 
@@ -130,8 +132,9 @@ RSpec.describe ::AptcCsr::AptcHouseholdContract, dbclean: :around_each do
           csr: nil,
           member_determination: [{
             kind: 'Insurance Assistance Determination',
-            is_eligible: true,
-            determination_reasons: [:income_above_threshold]
+            criteria_met: true,
+            determination_reasons: [:income_above_threshold],
+            eligibility_overrides: []
           }] }
       end
 

--- a/spec/contracts/aptc_csr/member_contract_spec.rb
+++ b/spec/contracts/aptc_csr/member_contract_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe ::AptcCsr::MemberContract, dbclean: :around_each do
       csr: '73',
       member_determinations: [{
         kind: 'Insurance Assistance Determination',
-        is_eligible: true,
-        determination_reasons: [:income_above_threshold]
+        criteria_met: true,
+        determination_reasons: [:income_above_threshold],
+        eligibility_overrides: []
       }] }
   end
 

--- a/spec/factories/aptc_household_members.rb
+++ b/spec/factories/aptc_household_members.rb
@@ -20,7 +20,8 @@ FactoryBot.define do
       [{
         kind: 'Insurance Assistance Determination',
         is_eligible: true,
-        determination_reasons: [:income_above_threshold]
+        determination_reasons: [:income_above_threshold],
+        eligibility_overrides: []
       }]
     end
 

--- a/spec/factories/aptc_household_members.rb
+++ b/spec/factories/aptc_household_members.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     member_determinations do
       [{
         kind: 'Insurance Assistance Determination',
-        is_eligible: true,
+        criteria_met: true,
         determination_reasons: [:income_above_threshold],
         eligibility_overrides: []
       }]


### PR DESCRIPTION
[TT6-185347179](https://www.pivotaltracker.com/story/show/185347179)
- add EligibilityOverride model, entity and contract
- persist additional data to db
- create default medicaid/chip member determination object when mitc response is processed
- create default eligibility override objects for each override rule on each member
- refactor field and variable names to be more clear

Note:
Typically we want to keep updates to the aca_entities ref separated from code changes, but  we'll need to keep them coupled in this case because we changed a field name on the MemberDetermination entity from is_eligible to criteria_met.