### PR TITLE
expect and store eligibility override rule as string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: bcc958349ef439b7f53f06bcad26a25e8e0b89ef
+  revision: 2b7a7c2f41bc6eed6580f45a26ee9dfceb9adb7a
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/contracts/aptc_csr/eligibility_override_contract.rb
+++ b/app/contracts/aptc_csr/eligibility_override_contract.rb
@@ -9,7 +9,7 @@ module AptcCsr
     # @param [Hash] opts the parameters to validate using this contract
     # @return [Dry::Monads::Result]
     params do
-      required(:override_rule).filled(Types::EligibilityOverrideRule)
+      required(:override_rule).filled(AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule)
       required(:override_applied).filled(:bool)
     end
   end

--- a/app/entities/aptc_csr/eligibility_override.rb
+++ b/app/entities/aptc_csr/eligibility_override.rb
@@ -4,7 +4,7 @@ module AptcCsr
   # An entity to represent a EligibilityOverride
   class EligibilityOverride < Dry::Struct
 
-    attribute :override_rule, Types::EligibilityOverrideRule
+    attribute :override_rule, AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule
     attribute :override_applied, Types::Bool
 
   end

--- a/app/models/medicaid/eligibility_override.rb
+++ b/app/models/medicaid/eligibility_override.rb
@@ -7,19 +7,14 @@ module Medicaid
     include Mongoid::Timestamps
 
     # The override rule that was applied.
-    field :override_rule, type: Symbol
+    field :override_rule, type: String
 
     # Whether or not the override was applied.
     field :override_applied, type: Boolean
 
     embedded_in :member_determination, class_name: '::Medicaid::MemberDetermination'
 
-    before_validation :symbolize_override_rule
-    validates_inclusion_of :override_rule, in: Types::EligibilityOverrideRule.values
+    validates_inclusion_of :override_rule, in: AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule.values
 
-    def symbolize_override_rule
-      return if override_rule.is_a?(Symbol)
-      self.override_rule = override_rule&.to_sym
-    end
   end
 end

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -173,9 +173,4 @@ module Types
     'Total Ineligibility Determination'
   )
 
-  EligibilityOverrideRule = Types::Coercible::Symbol.enum(
-    :not_lawfully_present_pregnant,
-    :not_lawfully_present_chip_eligible,
-    :not_lawfully_present_under_twenty_one
-  )
 end

--- a/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
+++ b/app/operations/eligibilities/aptc_csr/apply_eligibility_overrides.rb
@@ -41,17 +41,17 @@ module Eligibilities
       def apply_override_rule(thhm, rule)
         ped = thhm[:product_eligibility_determination]
         case rule
-        when :not_lawfully_present_pregnant
+        when 'not_lawfully_present_pregnant'
           if medicaid_ineligible_due_to_immigration_only?(thhm) && pregnancy_override?(thhm)
             ped[:is_magi_medicaid] = true
             update_member_determ_for(thhm, rule)
           end
-        when :not_lawfully_present_under_twenty_one
+        when 'not_lawfully_present_under_twenty_one'
           if medicaid_ineligible_due_to_immigration_only?(thhm) && nineteen_to_twenty_one_override?(thhm)
             ped[:is_magi_medicaid] = true
             update_member_determ_for(thhm, rule)
           end
-        when :not_lawfully_present_chip_eligible
+        when 'not_lawfully_present_chip_eligible'
           if medicaid_ineligible_due_to_immigration_only?(thhm) && under_eighteen_chip_override?(thhm)
             ped[:is_medicaid_chip_eligible] = true
             update_member_determ_for(thhm, rule)
@@ -113,7 +113,7 @@ module Eligibilities
         member_determs = thhm.dig(:product_eligibility_determination, :member_determinations)
         mdc_chip_determ = member_determs&.detect {|md| md[:kind] == 'Medicaid/CHIP Determination' }
         mdc_chip_determ[:criteria_met] = true
-        mdc_chip_determ[:determination_reasons] << rule
+        mdc_chip_determ[:determination_reasons] << rule.to_sym
         set_override_rule_applied(mdc_chip_determ[:eligibility_overrides], rule)
       end
 

--- a/components/mitc_service/Gemfile.lock
+++ b/components/mitc_service/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: bcc958349ef439b7f53f06bcad26a25e8e0b89ef
+  revision: 2b7a7c2f41bc6eed6580f45a26ee9dfceb9adb7a
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/spec/models/medicaid/eligibility_override.rb
+++ b/spec/models/medicaid/eligibility_override.rb
@@ -11,7 +11,7 @@ RSpec.describe ::Medicaid::EligibilityOverride, type: :model, dbclean: :after_ea
     }
   end
   context "validations" do
-    it { should validate_inclusion_of(:override_rule).in_array(Types::EligibilityOverrideRule.values) }
+    it { should validate_inclusion_of(:override_rule).in_array(AcaEntities::MagiMedicaid::Types::EligibilityOverrideRule.values) }
   end
 
   context "callbacks" do

--- a/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
+++ b/spec/operations/eligibilities/aptc_csr/apply_eligibility_overrides_spec.rb
@@ -129,9 +129,9 @@ describe Eligibilities::AptcCsr::ApplyEligibilityOverrides do
         it "should accurately record the override rules applied" do
           member_determs = @result.success.tax_households.first.tax_household_members.first.product_eligibility_determination.member_determinations
           eligibility_overrides = member_determs.first.eligibility_overrides
-          pregnant_override = eligibility_overrides.detect { |override| override.override_rule == :not_lawfully_present_pregnant }
-          under_twenty_one_override = eligibility_overrides.detect { |override| override.override_rule == :not_lawfully_present_under_twenty_one }
-          chip_eligible_override = eligibility_overrides.detect { |override| override.override_rule == :not_lawfully_present_chip_eligible }
+          pregnant_override = eligibility_overrides.detect { |override| override.override_rule == 'not_lawfully_present_pregnant' }
+          under_twenty_one_override = eligibility_overrides.detect { |override| override.override_rule == 'not_lawfully_present_under_twenty_one' }
+          chip_eligible_override = eligibility_overrides.detect { |override| override.override_rule == 'not_lawfully_present_chip_eligible' }
           expect(pregnant_override.override_applied).to eq(true)
           expect(under_twenty_one_override.override_applied).to eq(false)
           expect(chip_eligible_override.override_applied).to eq(false)


### PR DESCRIPTION
[TT6-185060667](https://www.pivotaltracker.com/story/show/185060667)

Note:
Updates to the aca_entities refs are included in this PR since the changes to how override_rules are stored are coupled to these aca_entities changes: https://github.com/ideacrew/aca_entities/pull/369