### PR TITLE
inferring false post partum for dc if nil in atp inbound

### DIFF
--- a/config/client_config/dc/system/config/templates/features/features.yml
+++ b/config/client_config/dc/system/config/templates/features/features.yml
@@ -67,3 +67,5 @@ registry:
             item: <%= ENV["MITC_OVERRIDE_NOT_LAWFULLY_PRESENT_UNDER_TWENTY_ONE_IS_ENABLED"] || false %>
       - key: :medicaid_eligible_incarcerated
         is_enabled: <%= ENV["MEDICAID_ELIGIBLE_INCARCERATED_IS_ENABLED"] || false %>
+      - key: :infer_post_partum_period
+        is_enabled: <%= ENV["INFER_POST_PARTUM_PERIOD_IS_ENABLED"] || false %>

--- a/config/client_config/me/system/config/templates/features/features.yml
+++ b/config/client_config/me/system/config/templates/features/features.yml
@@ -54,3 +54,5 @@ registry:
             item: <%= ENV["MITC_OVERRIDE_NOT_LAWFULLY_PRESENT_UNDER_TWENTY_ONE_IS_ENABLED"] || false %>
       - key: :medicaid_eligible_incarcerated
         is_enabled: <%= ENV["MEDICAID_ELIGIBLE_INCARCERATED_IS_ENABLED"] || false %>
+      - key: :infer_post_partum_period
+        is_enabled: <%= ENV["INFER_POST_PARTUM_PERIOD_IS_ENABLED"] || false %>

--- a/spec/domain/operations/transfers/to_enroll_spec.rb
+++ b/spec/domain/operations/transfers/to_enroll_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require 'aca_entities/serializers/xml/medicaid/atp'
-require 'aca_entities/atp/transformers/cv/family'
+require "aca_entities/serializers/xml/medicaid/atp"
+require "aca_entities/atp/transformers/cv/family"
 
 describe Transfers::ToEnroll, "given a soap envelope with an valid xml payload, transfer it to Enroll" do
 
   let(:transfer_id) { "tr123" }
   let(:body) { File.read("./spec/test_data/Simple_Test_Case_L_New.xml") }
   let(:process) { described_class.new }
+  let(:operation) { Transfers::ToEnroll.new }
 
   context 'success' do
     before :each do
@@ -23,6 +24,23 @@ describe Transfers::ToEnroll, "given a soap envelope with an valid xml payload, 
 
       it 'should return success with message' do
         expect(@result.success).to eq("Transferred account to Enroll")
+      end
+    end
+  end
+
+  context 'inferred post partum period' do
+    before do
+      allow(MedicaidGatewayRegistry).to receive(:feature_enabled?).with(:infer_post_partum_period).and_return(true)
+      @inbound_transfer = create :inbound_transfer, external_id: transfer_id
+      payload = operation.send(:create_transfer, body).success
+      transformed_params = operation.send(:transform_params, payload, @inbound_transfer.id).success
+      @updated_transformed_params = operation.send(:update_inferred_defaults, transformed_params).success
+    end
+
+    context 'transformed params with nil post partum' do
+      it 'should update to false' do
+        not_pregnant_applicant = @updated_transformed_params[:family][:magi_medicaid_applications][0][:applicants].first
+        expect(not_pregnant_applicant[:pregnancy_information][:is_post_partum_period]).to eq(false)
       end
     end
   end

--- a/spec/domain/operations/transfers/to_enroll_spec.rb
+++ b/spec/domain/operations/transfers/to_enroll_spec.rb
@@ -9,12 +9,11 @@ describe Transfers::ToEnroll, "given a soap envelope with an valid xml payload, 
   let(:transfer_id) { "tr123" }
   let(:body) { File.read("./spec/test_data/Simple_Test_Case_L_New.xml") }
   let(:process) { described_class.new }
-  let(:operation) { Transfers::ToEnroll.new }
+  let(:inbound_transfer) {create :inbound_transfer, external_id: transfer_id}
 
   context 'success' do
     before :each do
-      @inbound_transfer = create :inbound_transfer, external_id: transfer_id
-      @result = process.call(body, @inbound_transfer.id)
+      @result = process.call(body, inbound_transfer.id)
     end
 
     context 'with valid application' do
@@ -28,18 +27,19 @@ describe Transfers::ToEnroll, "given a soap envelope with an valid xml payload, 
     end
   end
 
+  let(:operation) { Transfers::ToEnroll.new }
+  let(:payload) {operation.send(:create_transfer, body).success}
+  let(:transformed_params) {operation.send(:transform_params, payload, inbound_transfer.id).success}
+  let(:updated_transformed_params) {operation.send(:update_inferred_defaults, transformed_params).success}
+
   context 'inferred post partum period' do
     before do
       allow(MedicaidGatewayRegistry).to receive(:feature_enabled?).with(:infer_post_partum_period).and_return(true)
-      @inbound_transfer = create :inbound_transfer, external_id: transfer_id
-      payload = operation.send(:create_transfer, body).success
-      transformed_params = operation.send(:transform_params, payload, @inbound_transfer.id).success
-      @updated_transformed_params = operation.send(:update_inferred_defaults, transformed_params).success
     end
 
     context 'transformed params with nil post partum' do
       it 'should update to false' do
-        not_pregnant_applicant = @updated_transformed_params[:family][:magi_medicaid_applications][0][:applicants].first
+        not_pregnant_applicant = updated_transformed_params[:family][:magi_medicaid_applications][0][:applicants].first
         expect(not_pregnant_applicant[:pregnancy_information][:is_post_partum_period]).to eq(false)
       end
     end

--- a/system/config/templates/features/features.yml
+++ b/system/config/templates/features/features.yml
@@ -54,3 +54,5 @@ registry:
             item: <%= ENV["MITC_OVERRIDE_NOT_LAWFULLY_PRESENT_UNDER_TWENTY_ONE_IS_ENABLED"] || false %>
       - key: :medicaid_eligible_incarcerated
         is_enabled: <%= ENV["MEDICAID_ELIGIBLE_INCARCERATED_IS_ENABLED"] || false %>
+      - key: :infer_post_partum_period
+        is_enabled: <%= ENV["INFER_POST_PARTUM_PERIOD_IS_ENABLED"] || false %>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185503807

DC wants nil post partum field to fill out as false - they use pregnancy_status to mean both current/past pregnancies so they want us to infer false if pregnancy_status is false

aca_entities will already set post_partum to nil if the pregnancy_status is false, so we can check if post_partum is nil and then update to false

FF: INFER_POST_PARTUM_PERIOD_IS_ENABLED
[x] DC
[ ] ME