### PR TITLE
add 2024 rr config for pediatric dental feature to support 2024 apps

### DIFF
--- a/config/client_config/dc/system/config/templates/features/products.yml
+++ b/config/client_config/dc/system/config/templates/features/products.yml
@@ -11,3 +11,5 @@ registry:
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2022_IS_ENABLED'] || false %>
           - key: :"2023"
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2023_IS_ENABLED'] || false %>
+          - key: :"2024"
+            item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2024_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/products.yml
+++ b/config/client_config/me/system/config/templates/features/products.yml
@@ -11,3 +11,5 @@ registry:
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2022_IS_ENABLED'] || false %>
           - key: :"2023"
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2023_IS_ENABLED'] || false %>
+          - key: :"2024"
+            item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2024_IS_ENABLED'] || false %>

--- a/system/config/templates/features/products.yml
+++ b/system/config/templates/features/products.yml
@@ -11,3 +11,5 @@ registry:
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2022_IS_ENABLED'] || false %>
           - key: :"2023"
             item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2023_IS_ENABLED'] || false %>
+          - key: :"2024"
+            item: <%= ENV['ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2024_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185261989

# A brief description of the changes

This PR is to mock 2024 eligibility settings for feature "Pediatric Dental Cost"

Current behavior: No 2024 setting for this feature

New behavior: Added 2024 setting for this feature

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `ATLEAST_ONE_SILVER_PLAN_DONOT_COVER_PEDIATRIC_DENTAL_COST_2024_IS_ENABLED`

 **Enabled for "Maine"
 Disabled for the "District of Columbia"**

- [x] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.