### PR TITLE
update affordability thresholds for 2024

### DIFF
--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -134,8 +134,9 @@ module Types
     { 2021 => BigDecimal('9.83') },
     { 2022 => BigDecimal('9.61') },
     { 2023 => BigDecimal('9.12') },
-    # adding 2024 values as placeholders to placate specs. These values are not verified.
-    { 2024 => BigDecimal('9.12') }
+    { 2024 => BigDecimal('8.39') },
+    # adding 2025 values as placeholders to placate specs. These values are not verified.
+    { 2025 => BigDecimal('8.39') }
   ].freeze
 
   CsrKind = Types::Coercible::String.enum(

--- a/components/mitc_service/spec/dummy/app/models/types.rb
+++ b/components/mitc_service/spec/dummy/app/models/types.rb
@@ -131,8 +131,9 @@ module Types
     { 2021 => BigDecimal('9.83') },
     { 2022 => BigDecimal('9.61') },
     { 2023 => BigDecimal('9.12') },
-    # adding 2024 values as placeholders to placate specs. These values are not verified.
-    { 2024 => BigDecimal('9.12') }
+    { 2024 => BigDecimal('8.39') },
+    # adding 2025 values as placeholders to placate specs. These values are not verified.
+    { 2025 => BigDecimal('8.39') }
   ].freeze
 
   CsrKind = Types::Coercible::String.enum('0',


### PR DESCRIPTION
[TT6-185904993](https://www.pivotaltracker.com/n/projects/2640057/stories/185904993)

- Add Affordability Configuration for 2024 and update value to reflect: **8.39%** from **9.12%** for 2023. 
- Add placeholder value for 2025 to avoid breaking tests