### PR TITLE
reconnect business validator proxy if first attempt crashes

### DIFF
--- a/app/operations/aces/process_atp_soap_request.rb
+++ b/app/operations/aces/process_atp_soap_request.rb
@@ -47,7 +47,7 @@ module Aces
         serialize_response_body(run_business_validations(string_payload))
       else
         payload = serialize_response_body(Success("not validated"))
-        @transfer.update!(payload: payload.value!)
+        @transfer.update!(payload: payload)
         payload
       end
     end

--- a/app/operations/aces/process_atp_soap_request.rb
+++ b/app/operations/aces/process_atp_soap_request.rb
@@ -32,9 +32,9 @@ module Aces
       _validation_result = yield validate_soap_header(parsed_payload)
       body_node = yield extract_top_body_node(parsed_payload)
       string_payload = yield convert_to_document_string(body_node)
-      serialized = run_validations_and_serialize(string_payload)
+      serialized = yield run_validations_and_serialize(string_payload)
       _transfer = yield transfer_account(string_payload, transfer_id, serialized)
-      serialized
+      Success(serialized)
     end
 
     protected
@@ -43,10 +43,11 @@ module Aces
       if @to_enroll
         schema_result = validate_document(string_payload)
         return serialize_response_body(schema_result) unless schema_result.success?
+
         serialize_response_body(run_business_validations(string_payload))
       else
         payload = serialize_response_body(Success("not validated"))
-        @transfer.update!(payload: payload)
+        @transfer.update!(payload: payload.value!)
         payload
       end
     end
@@ -151,9 +152,8 @@ module Aces
       end
     end
 
-    def transfer_account(payload, transfer_id, serialized)
+    def transfer_account(payload, transfer_id, _serialized)
       if @to_enroll
-        return serialized if serialized.failure?
         return Success(payload) if MedicaidGatewayRegistry.feature_enabled?(:bulk_transfer_to_enroll)
         return Success(payload) unless MedicaidGatewayRegistry.feature_enabled?(:transfer_to_enroll)
         Transfers::ToEnroll.new.call(payload, transfer_id)

--- a/app/operations/aces/process_atp_soap_request.rb
+++ b/app/operations/aces/process_atp_soap_request.rb
@@ -152,7 +152,7 @@ module Aces
       end
     end
 
-    def transfer_account(payload, transfer_id, _serialized)
+    def transfer_account(payload, transfer_id)
       if @to_enroll
         return Success(payload) if MedicaidGatewayRegistry.feature_enabled?(:bulk_transfer_to_enroll)
         return Success(payload) unless MedicaidGatewayRegistry.feature_enabled?(:transfer_to_enroll)

--- a/app/operations/aces/process_atp_soap_request.rb
+++ b/app/operations/aces/process_atp_soap_request.rb
@@ -33,7 +33,7 @@ module Aces
       body_node = yield extract_top_body_node(parsed_payload)
       string_payload = yield convert_to_document_string(body_node)
       serialized = yield run_validations_and_serialize(string_payload)
-      _transfer = yield transfer_account(string_payload, transfer_id, serialized)
+      _transfer = yield transfer_account(string_payload, transfer_id)
       Success(serialized)
     end
 

--- a/app/operations/transfers/execute_business_xml_validations.rb
+++ b/app/operations/transfers/execute_business_xml_validations.rb
@@ -23,6 +23,12 @@ module Transfers
     protected
 
     def execute_validator(payload)
+      result = AtpBusinessRulesValidationProxy.run_validation(payload)
+      # if the proxy does not throw an error, we can assume it was successful
+      Success(result)
+    rescue StandardError => e
+      # try to reconnect the proxy if initial attempt crashed
+      AtpBusinessRulesValidationProxy.reconnect!
       attempt = Try do
         AtpBusinessRulesValidationProxy.run_validation(payload)
       end

--- a/app/operations/transfers/execute_business_xml_validations.rb
+++ b/app/operations/transfers/execute_business_xml_validations.rb
@@ -27,8 +27,8 @@ module Transfers
       # if the proxy does not throw an error, we can assume it was successful
       Success(result)
     rescue StandardError => _e
-      # try to reconnect the proxy if initial attempt crashed
-      reconnect_proxy
+      # try to reconnect the proxy and run validation again if initial attempt crashed
+      AtpBusinessRulesValidationProxy.reconnect!
       attempt = Try do
         AtpBusinessRulesValidationProxy.run_validation(payload)
       end

--- a/app/operations/transfers/execute_business_xml_validations.rb
+++ b/app/operations/transfers/execute_business_xml_validations.rb
@@ -26,9 +26,9 @@ module Transfers
       result = AtpBusinessRulesValidationProxy.run_validation(payload)
       # if the proxy does not throw an error, we can assume it was successful
       Success(result)
-    rescue StandardError => e
+    rescue StandardError => _e
       # try to reconnect the proxy if initial attempt crashed
-      AtpBusinessRulesValidationProxy.reconnect!
+      reconnect_proxy
       attempt = Try do
         AtpBusinessRulesValidationProxy.run_validation(payload)
       end

--- a/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
+++ b/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
@@ -42,7 +42,6 @@ describe Transfers::ExecuteBusinessXmlValidations, dbclean: :after_each do
 
     before do
       allow(AtpBusinessRulesValidationProxy).to receive(:run_validation).with(payload).and_raise("Validator Crashed")
-      # allow(Transfers::ExecuteBusinessXmlValidations).to receive(:reconnect_proxy).and_return(AtpBusinessRulesValidationProxy.reconnect!)
     end
 
     context "second attempt" do

--- a/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
+++ b/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe Transfers::ExecuteBusinessXmlValidations, dbclean: :after_each do
+  include Dry::Monads[:result]
 
   let(:subject) do
     Transfers::ExecuteBusinessXmlValidations.new
@@ -36,21 +37,37 @@ describe Transfers::ExecuteBusinessXmlValidations, dbclean: :after_each do
   end
 
   context "validator crashed" do
+    let(:validator_result) do
+      <<-XMLCODE
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl">
+      </svrl:schematron-output>
+      XMLCODE
+    end
     let(:payload) { double }
-    let(:failure_result) { Failure(:validator_crashed) }
+    let(:stubbed_validation_responses) { [proc { raise StandardError }, proc { validator_result }] }
     let(:result) { subject.call(payload) }
 
     before do
-      allow(AtpBusinessRulesValidationProxy).to receive(:run_validation).with(payload).and_raise("Validator Crashed")
+      allow(AtpBusinessRulesValidationProxy).to receive(:run_validation).with(payload).exactly(:twice) { stubbed_validation_responses.shift.call }
+      allow(AtpBusinessRulesValidationProxy).to receive(:reconnect!).and_return(true)
     end
 
     context "second attempt" do
       it "should reconnect the proxy" do
         result
-        # expect(AtpBusinessRulesValidationProxy).to receive(:reconnect!)
+        expect(AtpBusinessRulesValidationProxy).to have_received(:reconnect!)
+      end
+
+      context 'second attempt succeeds' do
+        it "should return a success" do
+          expect(result.success?).to be_truthy
+        end
       end
 
       context "second attempt fails" do
+        let(:stubbed_validation_responses) { [proc { raise StandardError }, proc { raise StandardError }] }
+
         it "should return a failure" do
           expect(result.failure).to eq(:validator_crashed)
         end

--- a/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
+++ b/spec/domain/operations/transfers/execute_business_xml_validations_spec.rb
@@ -2,38 +2,60 @@
 
 require "rails_helper"
 
-describe Transfers::ExecuteBusinessXmlValidations, "given an empty payload" do
-  let(:payload) { "" }
+describe Transfers::ExecuteBusinessXmlValidations, dbclean: :after_each do
 
   let(:subject) do
     Transfers::ExecuteBusinessXmlValidations.new
   end
-  it "crashes" do
-    result = subject.call(payload)
-    expect(result.success?).not_to be_truthy
-  end
-end
+  let(:result) { subject.call(payload) }
 
-describe Transfers::ExecuteBusinessXmlValidations, "given a payload with an empty body" do
-  let(:payload) do
-    <<-XMLCODE
-    <ns8:AccountTransferRequest ns4:atVersionText="2.3" xmlns:ns2="http://hix.cms.gov/0.1/hix-core" xmlns:ns4="http://at.dsh.cms.gov/extension/1.0" xmlns:ns5="http://hix.cms.gov/0.1/hix-ee" xmlns:ns6="http://niem.gov/niem/domains/screening/2.1" xmlns:ns7="http://hix.cms.gov/0.1/hix-pm" xmlns:ns8="http://at.dsh.cms.gov/exchange/1.0">
-    </ns8:AccountTransferRequest>
-    XMLCODE
+  context "given an empty payload" do
+    let(:payload) { "" }
+
+    it "crashes" do
+      expect(result.success?).not_to be_truthy
+    end
   end
 
-  let(:subject) do
-    Transfers::ExecuteBusinessXmlValidations.new
+  context "given a payload with an empty body" do
+    let(:payload) do
+      <<-XMLCODE
+      <ns8:AccountTransferRequest ns4:atVersionText="2.3" xmlns:ns2="http://hix.cms.gov/0.1/hix-core" xmlns:ns4="http://at.dsh.cms.gov/extension/1.0" xmlns:ns5="http://hix.cms.gov/0.1/hix-ee" xmlns:ns6="http://niem.gov/niem/domains/screening/2.1" xmlns:ns7="http://hix.cms.gov/0.1/hix-pm" xmlns:ns8="http://at.dsh.cms.gov/exchange/1.0">
+      </ns8:AccountTransferRequest>
+      XMLCODE
+    end
+
+    it "fails" do
+      expect(result.success?).not_to be_truthy
+    end
+
+    it "returns the errors" do
+      failure_object = result.failure
+      expect(failure_object.is_a?(Aces::AtpBusinessRuleFailure)).to be_truthy
+    end
   end
 
-  it "fails" do
-    result = subject.call(payload)
-    expect(result.success?).not_to be_truthy
-  end
+  context "validator crashed" do
+    let(:payload) { double }
+    let(:failure_result) { Failure(:validator_crashed) }
+    let(:result) { subject.call(payload) }
 
-  it "returns the errors" do
-    result = subject.call(payload)
-    failure_object = result.failure
-    expect(failure_object.is_a?(Aces::AtpBusinessRuleFailure)).to be_truthy
+    before do
+      allow(AtpBusinessRulesValidationProxy).to receive(:run_validation).with(payload).and_raise("Validator Crashed")
+      # allow(Transfers::ExecuteBusinessXmlValidations).to receive(:reconnect_proxy).and_return(AtpBusinessRulesValidationProxy.reconnect!)
+    end
+
+    context "second attempt" do
+      it "should reconnect the proxy" do
+        result
+        # expect(AtpBusinessRulesValidationProxy).to receive(:reconnect!)
+      end
+
+      context "second attempt fails" do
+        it "should return a failure" do
+          expect(result.failure).to eq(:validator_crashed)
+        end
+      end
+    end
   end
 end

--- a/spec/reports/transfer_report_spec.rb
+++ b/spec/reports/transfer_report_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe TransferReport, dbclean: :after_each do
   describe "#run" do
     context 'summary of all transfers' do
       before do
+        allow(MedicaidGatewayRegistry).to receive(:feature_enabled?).with(:transfer_to_enroll).and_return(true)
         Dir[Rails.root.join("transfer_report_*.csv")].each { |filename| FileUtils.rm_rf(filename) }
         create_date = DateTime.now.utc - 1.day
         create :transfer, created_at: create_date


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2640057/stories/187278915

When debugging the attached ticket in the MG Rails console, I noticed that the validator intermittently crashes, however, reconnecting the validator would always result in a successful connection and validation for the cases I was testing.

This PR adds an attempt to the reconnect the validator and run the validations again if the initial attempt fails in `Transfers::ExecuteBusinessXmlValidations`.

Additional changes:
- modified a method in `Aces::ProcessAtpSoapRequest` to implement the Dry::Monads pattern consistently
- stubbed a feature flag in TransferReport spec to decouple the spec from runtime client config