### PR TITLE
Fixes yard doc

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "trunk"
-      - 'fixes_yard_doc'
+      - 'trunk'
 
 jobs:
   docsite:

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "trunk"
+      - 'fixes_yard_doc'
 
 jobs:
   docsite:

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -1,0 +1,44 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+
+{{ $outputFormat := partial "outputformat.html" . -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
+<meta name="robots" content="index, follow">
+{{ else -}}
+<meta name="robots" content="noindex, nofollow">
+{{ end -}}
+
+{{ partialCached "favicons.html" . }}
+<title>
+  {{- if .IsHome -}}
+    {{ .Site.Title -}}
+  {{ else -}}
+    {{ with .Title }}{{ . }} | {{ end -}}
+    {{ .Site.Title -}}
+  {{ end -}}
+</title>
+<meta name="description" content="{{ template "partials/page-description.html" . }}">
+{{ template "_internal/opengraph.html" . -}}
+{{ template "_internal/schema.html" . -}}
+{{ template "_internal/twitter_cards.html" . -}}
+{{ partialCached "head-css.html" . "asdf" -}}
+<script
+  src="https://code.jquery.com/jquery-3.6.3.min.js"
+  integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ=="
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch -}}
+<script defer
+  src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
+  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  crossorigin="anonymous"></script>
+{{ end -}}
+
+{{ if .Site.Params.prism_syntax_highlighting -}}
+<link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
+{{ end -}}
+
+{{ partial "hooks/head-end.html" . -}}


### PR DESCRIPTION
- Removes the Google Analytics from the template in the documentation - preventing a conflict with building documents. This now builds the Hugo Documentation correctly.
- Reference for the fix: https://github.com/ideacrew/enroll/pull/3758
- Included the current branch to build the docs and it builds green.
<img width="839" alt="image" src="https://github.com/user-attachments/assets/22ab5924-bb0f-4c7a-baf9-1b163e0ce86a">
