### PR TITLE
added scheduled run to mg for automated tests

### DIFF
--- a/.github/workflows/quality_workbench.yml
+++ b/.github/workflows/quality_workbench.yml
@@ -2,9 +2,12 @@ name: Quality Workbench
 on:
   push:
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
 
 concurrency:
-  group: qb-${{ github.ref }}
+  group: qb-${{ github.ref }}-automated-test
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR adds an scheduled run at 5 am to be in-line with other micro-services to make sure trunk is not broken