### PR TITLE
Correct boot process for legacy unicorn servers.

### DIFF
--- a/.docker/config/unicorn.rb
+++ b/.docker/config/unicorn.rb
@@ -2,6 +2,9 @@ root_path = File.expand_path(File.join(File.dirname(__FILE__), ".."))
 #shared_path = File.expand_path(File.join(root_path, "..", "shared"))
 
 working_directory root_path
+
+ENV['RUNNING_UNICORN'] = 'true'
+
 pid root_path + "/pids/unicorn.pid"
 stderr_path root_path + "/log/unicorn.log"
 stdout_path root_path + "/log/unicorn.log"
@@ -14,5 +17,5 @@ preload_app true
 
 after_fork do |server, worker|
   Rails.logger.info { "Rebooting Validation Proxy for worker" }
-  AtpBusinessRulesValidationProxy.reconnect!
+  AtpBusinessRulesValidationProxy.boot!
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module MedicaidGateway
     config.generators.system_tests = nil
 
     config.after_initialize do
-      AtpBusinessRulesValidationProxy.boot!
+      AtpBusinessRulesValidationProxy.boot! unless ENV['RUNNING_UNICORN'] == 'true'
     end
   end
 end


### PR DESCRIPTION
Introduce updates to validation to prevent crashes from not enough validators and include new validation behaviour which allows additional reasons for transfer.

Ticket: https://www.pivotaltracker.com/story/show/187862357